### PR TITLE
mcp_stdio_client: fix Python subprocess output loss on Unix-like systems by switching to blocking read

### DIFF
--- a/examples/stdio_client_example.cpp
+++ b/examples/stdio_client_example.cpp
@@ -51,26 +51,30 @@ int main(int argc, char** argv) {
         std::cout << "Server capabilities: " << capabilities.dump(2) << std::endl;
         
         // List available tools
-        auto tools = client.get_tools();
-        std::cout << "Available tools: " << tools.size() << std::endl;
-        for (const auto& tool : tools) {
-            std::cout << "  - " << tool.name << ": " << tool.description << std::endl;
-            // std::cout << tool.to_json().dump(2) << std::endl;
+        if (capabilities.contains("tools")) {
+            auto tools = client.get_tools();
+            std::cout << "Available tools: " << tools.size() << std::endl;
+            for (const auto& tool : tools) {
+                std::cout << "  - " << tool.name << ": " << tool.description << std::endl;
+                // std::cout << tool.to_json().dump(2) << std::endl;
+            }
         }
         
         // List available resources
-        auto resources = client.list_resources();
-        std::cout << "Available resources: " << resources.dump(2) << std::endl;
-        
-        // If there are resources, read the first one
-        if (resources.contains("resources") && resources["resources"].is_array() && !resources["resources"].empty()) {
-            auto resource = resources["resources"][0];
-            if (resource.contains("uri")) {
-                std::string uri = resource["uri"];
-                std::cout << "Reading resource: " << uri << std::endl;
-                
-                auto content = client.read_resource(uri);
-                std::cout << "Resource content: " << content.dump(2) << std::endl;
+        if (capabilities.contains("resources")) {
+            auto resources = client.list_resources();
+            std::cout << "Available resources: " << resources.dump(2) << std::endl;
+            
+            // If there are resources, read the first one
+            if (resources.contains("resources") && resources["resources"].is_array() && !resources["resources"].empty()) {
+                auto resource = resources["resources"][0];
+                if (resource.contains("uri")) {
+                    std::string uri = resource["uri"];
+                    std::cout << "Reading resource: " << uri << std::endl;
+                    
+                    auto content = client.read_resource(uri);
+                    std::cout << "Resource content: " << content.dump(2) << std::endl;
+                }
             }
         }
         

--- a/src/mcp_stdio_client.cpp
+++ b/src/mcp_stdio_client.cpp
@@ -637,7 +637,7 @@ void stdio_client::read_thread_func() {
                                 // Currently not handling requests from the server
                             }
                         }
-                    } catch (const json::exception& e) {
+                    } catch (const json::exception& /* e */) {
                         LOG_INFO("message: ", line);
                     }
                 }
@@ -662,7 +662,7 @@ void stdio_client::read_thread_func() {
                 
                 // Retry after a short delay
                 std::this_thread::sleep_for(std::chrono::milliseconds(50 * retry_count));
-            } else if (error != ERROR_IO_PENDING) {
+            } else if (error != ERROR_IO_PENDING && error != ERROR_NO_DATA) {
                 // Other errors, log and retry
                 LOG_ERROR("Error reading from pipe: ", error);
                 retry_count++;


### PR DESCRIPTION
Based on issue identified in PR #5 by @JPChen2000, we fixed a bug where only the first message could be read from a Python subprocess when using non-blocking pipe reads on Unix-like systems.
The root cause is due to Python's platform-specific buffering behavior for stdout when redirected to a pipe:

| Platform | Python stdout Buffering | Compatible with Non-blocking Read? | Problem Symptoms | Fix Strategy |
| :- | :- | :- | :- | :- |
| Linux/macOS | Fully buffered (when not a TTY) | ❌ No | Only the first message is read; subsequent reads return nothing unless explicitly flushed | ✅ Switch to blocking read to wait for data |
| Windows | Line buffered (even when redirected) | ✅ Yes | All messages are read as expected | 🔄 Keep non-blocking read behavior |