### PR TITLE
Create an install target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TARGET mcp)
 
-add_library(${TARGET} STATIC
+# Create shared library
+add_library(${TARGET} SHARED
     ../include/mcp_client.h
     mcp_message.cpp
     ../include/mcp_message.h
@@ -22,3 +23,17 @@ target_link_libraries(${TARGET} PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 if(OPENSSL_FOUND)
     target_link_libraries(${TARGET} PUBLIC ${OPENSSL_LIBRARIES})
 endif()
+
+# Set properties for shared library
+set_target_properties(${TARGET} PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION 1
+    PUBLIC_HEADER "../include/mcp_client.h;../include/mcp_message.h;../include/mcp_resource.h;../include/mcp_server.h;../include/mcp_tool.h;../include/mcp_stdio_client.h;../include/mcp_sse_client.h"
+)
+
+# Install rules
+include(GNUInstallDirs)
+install(TARGETS ${TARGET}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mcp
+)


### PR DESCRIPTION
I want to add MCP to some existing servers, and to do that, it seems that a shared library plus installed header files are needed. This change allows `sudo make install` to run, giving
```
Install the project...
-- Install configuration: "Release"
-- Installing: /usr/local/lib/libmcp.so.2024.11.5
-- Installing: /usr/local/lib/libmcp.so.1
-- Installing: /usr/local/lib/libmcp.so
-- Installing: /usr/local/include/mcp/mcp_client.h
-- Installing: /usr/local/include/mcp/mcp_message.h
-- Installing: /usr/local/include/mcp/mcp_resource.h
-- Installing: /usr/local/include/mcp/mcp_server.h
-- Installing: /usr/local/include/mcp/mcp_tool.h
-- Installing: /usr/local/include/mcp/mcp_stdio_client.h
-- Installing: /usr/local/include/mcp/mcp_sse_client.h
```

This delta was created with claude, I have not yet tested to see if it "did the right thing", but so far, it looks OK to me ...