### PR TITLE
Revise mcp_stdio_client to contact existing server

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(${TARGET} stdio_client_example.cpp)
 target_link_libraries(${TARGET} PRIVATE mcp)
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
+
 set(TARGET server_example)
 add_executable(${TARGET} server_example.cpp)
 target_link_libraries(${TARGET} PRIVATE mcp)
@@ -30,3 +31,6 @@ target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/include)
 if(OPENSSL_FOUND)
     target_link_libraries(${TARGET} PRIVATE ${OPENSSL_LIBRARIES})
 endif()
+
+# Add network subdirectory
+add_subdirectory(network)

--- a/examples/network/CMakeLists.txt
+++ b/examples/network/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+# Network Client Example
+set(TARGET network_client_example)
+add_executable(${TARGET} network_client_example.cpp)
+target_link_libraries(${TARGET} PRIVATE mcp)
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
+# Simple TCP Server Example (for testing network client)
+set(TARGET simple_tcp_server)
+add_executable(${TARGET} simple_tcp_server.cpp)
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/common)

--- a/examples/network/README.md
+++ b/examples/network/README.md
@@ -1,0 +1,223 @@
+# MCP Network Examples
+
+This directory contains examples demonstrating the **network communication features** of the MCP (Model Context Protocol) C++ framework, specifically the enhanced `stdio_client` that can connect to existing servers via TCP.
+
+## Building Examples
+
+First, build the project from the repository root directory:
+
+```bash
+cd /path/to/cpp-mcp
+cmake -B build
+cmake --build build --config Release
+```
+
+All examples will be built and placed in the `build/examples/network/` directory.
+
+## Network Communication Examples
+
+This directory focuses on the **new network communication capabilities** added to the MCP framework.
+
+### 1. Network Client Example (`network_client_example`)
+
+Demonstrates the **new network connection capability** of the stdio client. Instead of spawning a subprocess, this client connects to an already-running MCP server via TCP.
+
+**Key Features:**
+- Connects to existing MCP servers via TCP socket
+- No subprocess spawning required
+- Full MCP protocol support (tools, resources, etc.)
+- Command-line configuration for host and port
+
+**Usage:**
+```bash
+./build/examples/network/network_client_example [options]
+```
+
+**Options:**
+- `-h, --host <host>`: Server host (default: localhost)
+- `-p, --port <port>`: Server port (default: 8080)
+- `--help`: Show help message
+
+**Examples:**
+```bash
+# Connect to localhost on port 8080
+./build/examples/network/network_client_example
+
+# Connect to specific host and port
+./build/examples/network/network_client_example --host 127.0.0.1 --port 9999
+
+# Connect to remote server
+./build/examples/network/network_client_example --host example.com --port 8080
+```
+
+### 2. Simple TCP Server (`simple_tcp_server`)
+
+A minimal TCP-based MCP server for testing the network client functionality.
+
+**Key Features:**
+- Pure TCP socket communication
+- JSON-RPC over newline-delimited format
+- Implements basic MCP protocol methods
+- Provides test tools (echo, time)
+
+**Usage:**
+```bash
+./build/examples/network/simple_tcp_server [port]
+```
+
+**Examples:**
+```bash
+# Start server on default port 8080
+./build/examples/network/simple_tcp_server
+
+# Start server on specific port
+./build/examples/network/simple_tcp_server 9999
+```
+
+**Available Methods:**
+- `initialize`: Initialize MCP connection
+- `ping`: Health check
+- `tools/list`: List available tools
+- `tools/call`: Call a tool (echo, time)
+- `resources/list`: List resources (empty for this example)
+
+## Testing Network Communication
+
+Here's how to test the new network communication features:
+
+### Quick Test
+
+1. **Start the TCP server:**
+   ```bash
+   ./build/examples/network/simple_tcp_server 8080
+   ```
+
+2. **In another terminal, connect with the network client:**
+   ```bash
+   ./build/examples/network/network_client_example --host localhost --port 8080
+   ```
+
+You should see output showing successful connection, tool listing, and tool execution.
+
+### Advanced Testing
+
+1. **Test with different ports:**
+   ```bash
+   # Terminal 1: Start server on port 9999
+   ./build/examples/network/simple_tcp_server 9999
+   
+   # Terminal 2: Connect to port 9999
+   ./build/examples/network/network_client_example --port 9999
+   ```
+
+2. **Test with external MCP servers:**
+   If you have other MCP servers that support TCP connections, you can connect to them:
+   ```bash
+   ./build/examples/network/network_client_example --host <server_host> --port <server_port>
+   ```
+
+## Stdio Client: Two Connection Modes
+
+The `mcp_stdio_client` now supports **two distinct connection modes**:
+
+### 1. Subprocess Mode (Original)
+```cpp
+// Spawns a subprocess and communicates via pipes
+mcp::stdio_client client("npx -y @modelcontextprotocol/server-filesystem");
+```
+
+### 2. Network Mode (New) 🆕
+```cpp
+// Connects to existing server via TCP
+mcp::stdio_client client("localhost", 8080);
+```
+
+Both modes provide identical functionality - the only difference is the transport mechanism.
+
+## Protocol Details
+
+All examples implement the [MCP 2024-11-05 specification](https://spec.modelcontextprotocol.io/specification/2024-11-05/architecture/).
+
+**Communication Format:**
+- JSON-RPC 2.0 over newline-delimited JSON
+- Each message ends with `\n`
+- Supports both requests/responses and notifications
+
+**Standard Methods:**
+- `initialize`: Establish connection and exchange capabilities
+- `ping`: Health check
+- `tools/list`: Enumerate available tools
+- `tools/call`: Execute a tool
+- `resources/list`: List available resources
+- `resources/read`: Read resource content
+
+## Troubleshooting
+
+### Network Client Issues
+
+**"Failed to connect to server: Connection refused"**
+- Ensure the target server is running and listening on the specified port
+- Check if the port is accessible (not blocked by firewall)
+- Verify the host and port are correct
+
+**"Failed to connect to server: Operation not permitted"**
+- Try using a port number > 1024
+- Check if another process is using the same port
+- Ensure you have network permissions
+
+### TCP Server Issues
+
+**"Failed to bind socket to port: Address already in use"**
+- Another process is using the port
+- Wait a moment for the port to be released, or use a different port
+- Kill any existing server processes: `pkill -f simple_tcp_server`
+
+**"Failed to listen on socket: Operation not permitted"**
+- Try using a port number > 1024 (ports 1-1024 require root privileges)
+- Example: `./build/examples/network/simple_tcp_server 8080`
+
+### General Issues
+
+**Build errors:**
+```bash
+# Clean and rebuild
+rm -rf build
+cmake -B build
+cmake --build build --config Release
+```
+
+**SSL-related issues with HTTPS servers:**
+```bash
+# Build with SSL support
+cmake -B build -DMCP_SSL=ON
+cmake --build build --config Release
+```
+
+## Development
+
+### Adding New Examples
+
+1. Create your example file in the `examples/` directory
+2. Add it to `examples/CMakeLists.txt`:
+   ```cmake
+   set(TARGET your_example)
+   add_executable(${TARGET} your_example.cpp)
+   target_link_libraries(${TARGET} PRIVATE mcp)
+   target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/include)
+   ```
+3. Rebuild the project
+
+### Extending the Network Client
+
+The network client example (`network_client_example.cpp`) serves as a template for building custom MCP clients. Key areas to modify:
+
+- **Tool Arguments**: Customize the arguments passed to different tools
+- **Error Handling**: Add specific error handling for your use case
+- **Resource Processing**: Add custom logic for handling different resource types
+- **Connection Logic**: Add authentication, custom headers, etc.
+
+## Further Reading
+
+- [MCP Specification](https://spec.modelcontextprotocol.io/)
+- [Main README](../../README.md) - Framework overview and build instructions
+- [MCP Servers](https://www.pulsemcp.com/servers) - Community MCP server implementations

--- a/examples/network/network_client_example.cpp
+++ b/examples/network/network_client_example.cpp
@@ -1,0 +1,160 @@
+/**
+ * @file network_client_example.cpp
+ * @brief Example demonstrating MCP stdio client connecting to existing server via TCP
+ * 
+ * This example shows how to use the stdio_client to connect to an already-running
+ * MCP server via TCP socket connection instead of spawning a subprocess.
+ */
+
+#include "mcp_stdio_client.h"
+#include "mcp_logger.h"
+
+#include <iostream>
+#include <string>
+#include <chrono>
+#include <thread>
+
+using namespace mcp;
+
+void print_usage(const char* program_name) {
+    std::cout << "Usage: " << program_name << " [options]\n"
+              << "Options:\n"
+              << "  -h, --host <host>     Server host (default: localhost)\n"
+              << "  -p, --port <port>     Server port (default: 8080)\n"
+              << "  --help               Show this help message\n"
+              << "\n"
+              << "Example:\n"
+              << "  " << program_name << " --host localhost --port 8080\n"
+              << "\n"
+              << "This client connects to an existing MCP server running on the specified\n"
+              << "host and port. Make sure the server is already running before connecting.\n";
+}
+
+int main(int argc, char* argv[]) {
+    std::string host = "localhost";
+    int port = 8080;
+    
+    // Parse command line arguments
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        
+        if (arg == "--help") {
+            print_usage(argv[0]);
+            return 0;
+        } else if ((arg == "-h" || arg == "--host") && i + 1 < argc) {
+            host = argv[++i];
+        } else if ((arg == "-p" || arg == "--port") && i + 1 < argc) {
+            port = std::stoi(argv[++i]);
+        } else {
+            std::cerr << "Unknown argument: " << arg << std::endl;
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+    
+    std::cout << "MCP Network Client Example\n";
+    std::cout << "Connecting to: " << host << ":" << port << std::endl;
+    
+    try {
+        // Create client with network connection
+        stdio_client client(host, port);
+        
+        // Initialize the client
+        std::cout << "Initializing client..." << std::endl;
+        if (!client.initialize("NetworkClientExample", "1.0.0")) {
+            std::cerr << "Failed to initialize client" << std::endl;
+            return 1;
+        }
+        
+        std::cout << "✓ Client initialized successfully" << std::endl;
+        
+        // Test ping
+        std::cout << "\nTesting ping..." << std::endl;
+        if (client.ping()) {
+            std::cout << "✓ Ping successful" << std::endl;
+        } else {
+            std::cout << "✗ Ping failed" << std::endl;
+        }
+        
+        // Get server capabilities
+        std::cout << "\nGetting server capabilities..." << std::endl;
+        try {
+            json capabilities = client.get_server_capabilities();
+            std::cout << "✓ Server capabilities: " << capabilities.dump(2) << std::endl;
+        } catch (const std::exception& e) {
+            std::cout << "✗ Failed to get server capabilities: " << e.what() << std::endl;
+        }
+        
+        // List available tools
+        std::cout << "\nListing available tools..." << std::endl;
+        try {
+            auto tools = client.get_tools();
+            std::cout << "✓ Found " << tools.size() << " tools:" << std::endl;
+            
+            for (const auto& tool : tools) {
+                std::cout << "  - " << tool.name << ": " << tool.description << std::endl;
+            }
+            
+            // Call a tool if available
+            if (!tools.empty()) {
+                const auto& first_tool = tools[0];
+                std::cout << "\nCalling tool '" << first_tool.name << "'..." << std::endl;
+                
+                json tool_args;
+                // Add some example arguments based on common tool types
+                if (first_tool.name == "echo") {
+                    tool_args["text"] = "Hello from network client!";
+                } else if (first_tool.name == "greeting") {
+                    tool_args["name"] = "NetworkClient";
+                } else if (first_tool.name == "time") {
+                    // No arguments needed for time tool
+                }
+                
+                try {
+                    json result = client.call_tool(first_tool.name, tool_args);
+                    std::cout << "✓ Tool result: " << result.dump(2) << std::endl;
+                } catch (const std::exception& e) {
+                    std::cout << "✗ Tool call failed: " << e.what() << std::endl;
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cout << "✗ Failed to list tools: " << e.what() << std::endl;
+        }
+        
+        // List available resources
+        std::cout << "\nListing available resources..." << std::endl;
+        try {
+            json resources = client.list_resources();
+            std::cout << "✓ Resources: " << resources.dump(2) << std::endl;
+            
+            // Try to read a resource if available
+            if (resources.contains("resources") && resources["resources"].is_array() && 
+                !resources["resources"].empty()) {
+                
+                const auto& first_resource = resources["resources"][0];
+                if (first_resource.contains("uri")) {
+                    std::string uri = first_resource["uri"];
+                    std::cout << "\nReading resource: " << uri << std::endl;
+                    
+                    try {
+                        json content = client.read_resource(uri);
+                        std::cout << "✓ Resource content: " << content.dump(2) << std::endl;
+                    } catch (const std::exception& e) {
+                        std::cout << "✗ Failed to read resource: " << e.what() << std::endl;
+                    }
+                }
+            }
+        } catch (const std::exception& e) {
+            std::cout << "✗ Failed to list resources: " << e.what() << std::endl;
+        }
+        
+        std::cout << "\n✓ All operations completed successfully!" << std::endl;
+        std::cout << "The client connected to an existing server without spawning a subprocess." << std::endl;
+        
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    }
+    
+    return 0;
+}

--- a/examples/network/simple_tcp_server.cpp
+++ b/examples/network/simple_tcp_server.cpp
@@ -1,0 +1,332 @@
+/**
+ * @file simple_tcp_server.cpp
+ * @brief Simple TCP server for testing network stdio client
+ * 
+ * This is a minimal MCP server that accepts TCP connections and responds 
+ * to JSON-RPC requests, specifically for testing the network stdio client.
+ */
+
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+#include <sstream>
+#include <cstring>
+#include <chrono>
+#include <ctime>
+
+#if defined(_WIN32)
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+#endif
+
+#include "json.hpp"
+
+using json = nlohmann::json;
+
+class SimpleTcpServer {
+private:
+    int server_fd_;
+    int port_;
+    bool running_;
+
+public:
+    SimpleTcpServer(int port) : server_fd_(-1), port_(port), running_(false) {}
+    
+    ~SimpleTcpServer() {
+        stop();
+    }
+    
+    bool start() {
+#if defined(_WIN32)
+        WSADATA wsaData;
+        if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
+            std::cerr << "WSAStartup failed" << std::endl;
+            return false;
+        }
+#endif
+        
+        // Create socket
+        server_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (server_fd_ < 0) {
+            std::cerr << "Failed to create socket" << std::endl;
+#if defined(_WIN32)
+            WSACleanup();
+#endif
+            return false;
+        }
+        
+        // Allow socket reuse
+        int opt = 1;
+#if defined(_WIN32)
+        if (setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, (char*)&opt, sizeof(opt)) < 0) {
+            std::cerr << "Failed to set socket options: " << WSAGetLastError() << std::endl;
+#else
+        if (setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
+            std::cerr << "Failed to set socket options: " << strerror(errno) << std::endl;
+#endif
+#if defined(_WIN32)
+            closesocket(server_fd_);
+            WSACleanup();
+#else
+            close(server_fd_);
+#endif
+            return false;
+        }
+        
+        // Bind socket
+        struct sockaddr_in address;
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = INADDR_ANY;
+        address.sin_port = htons(port_);
+        
+        if (bind(server_fd_, (struct sockaddr*)&address, sizeof(address)) < 0) {
+#if defined(_WIN32)
+            std::cerr << "Failed to bind socket to port " << port_ << ": " << WSAGetLastError() << std::endl;
+#else
+            std::cerr << "Failed to bind socket to port " << port_ << ": " << strerror(errno) << std::endl;
+#endif
+#if defined(_WIN32)
+            closesocket(server_fd_);
+            WSACleanup();
+#else
+            close(server_fd_);
+#endif
+            return false;
+        }
+        
+        // Listen for connections
+        if (listen(server_fd_, 3) < 0) {
+#if defined(_WIN32)
+            std::cerr << "Failed to listen on socket: " << WSAGetLastError() << std::endl;
+#else
+            std::cerr << "Failed to listen on socket: " << strerror(errno) << std::endl;
+#endif
+#if defined(_WIN32)
+            closesocket(server_fd_);
+            WSACleanup();
+#else
+            close(server_fd_);
+#endif
+            return false;
+        }
+        
+        running_ = true;
+        std::cout << "Simple TCP MCP server listening on port " << port_ << std::endl;
+        return true;
+    }
+    
+    void stop() {
+        running_ = false;
+        if (server_fd_ >= 0) {
+#if defined(_WIN32)
+            closesocket(server_fd_);
+            WSACleanup();
+#else
+            close(server_fd_);
+#endif
+            server_fd_ = -1;
+        }
+    }
+    
+    void run() {
+        while (running_) {
+            struct sockaddr_in client_address;
+            socklen_t client_len = sizeof(client_address);
+            
+            int client_fd = accept(server_fd_, (struct sockaddr*)&client_address, &client_len);
+            if (client_fd < 0) {
+                if (running_) {
+                    std::cerr << "Failed to accept client connection" << std::endl;
+                }
+                continue;
+            }
+            
+            std::cout << "Client connected" << std::endl;
+            
+            // Handle client in a separate thread
+            std::thread client_thread(&SimpleTcpServer::handle_client, this, client_fd);
+            client_thread.detach();
+        }
+    }
+    
+private:
+    void handle_client(int client_fd) {
+        char buffer[4096];
+        std::string data_buffer;
+        
+        while (running_) {
+            ssize_t bytes_read = recv(client_fd, buffer, sizeof(buffer) - 1, 0);
+            
+            if (bytes_read <= 0) {
+                break; // Client disconnected
+            }
+            
+            buffer[bytes_read] = '\0';
+            data_buffer.append(buffer, bytes_read);
+            
+            // Process complete JSON-RPC messages
+            size_t pos = 0;
+            while ((pos = data_buffer.find('\n')) != std::string::npos) {
+                std::string line = data_buffer.substr(0, pos);
+                data_buffer.erase(0, pos + 1);
+                
+                if (!line.empty()) {
+                    std::string response = process_request(line);
+                    if (!response.empty()) {
+                        response += "\n";
+                        send(client_fd, response.c_str(), response.length(), 0);
+                    }
+                }
+            }
+        }
+        
+        std::cout << "Client disconnected" << std::endl;
+#if defined(_WIN32)
+        closesocket(client_fd);
+#else
+        close(client_fd);
+#endif
+    }
+    
+    std::string process_request(const std::string& request_str) {
+        try {
+            json request = json::parse(request_str);
+            
+            if (!request.contains("jsonrpc") || request["jsonrpc"] != "2.0") {
+                return ""; // Invalid JSON-RPC
+            }
+            
+            std::string method = request.value("method", "");
+            json params = request.value("params", json::object());
+            json id = request.value("id", json());
+            
+            json response;
+            response["jsonrpc"] = "2.0";
+            response["id"] = id;
+            
+            if (method == "initialize") {
+                response["result"] = {
+                    {"protocolVersion", "2024-11-05"},
+                    {"capabilities", {
+                        {"tools", json::object()},
+                        {"resources", json::object()}
+                    }},
+                    {"serverInfo", {
+                        {"name", "SimpleTcpServer"},
+                        {"version", "1.0.0"}
+                    }}
+                };
+            } else if (method == "initialized") {
+                // Notification - no response
+                return "";
+            } else if (method == "ping") {
+                response["result"] = json::object();
+            } else if (method == "tools/list") {
+                response["result"] = {
+                    {"tools", {
+                        {
+                            {"name", "echo"},
+                            {"description", "Echo the input text"},
+                            {"inputSchema", {
+                                {"type", "object"},
+                                {"properties", {
+                                    {"text", {
+                                        {"type", "string"},
+                                        {"description", "Text to echo"}
+                                    }}
+                                }},
+                                {"required", {"text"}}
+                            }}
+                        },
+                        {
+                            {"name", "time"},
+                            {"description", "Get current time"},
+                            {"inputSchema", {
+                                {"type", "object"},
+                                {"properties", json::object()}
+                            }}
+                        }
+                    }}
+                };
+            } else if (method == "tools/call") {
+                std::string tool_name = params.value("name", "");
+                json arguments = params.value("arguments", json::object());
+                
+                if (tool_name == "echo") {
+                    std::string text = arguments.value("text", "");
+                    response["result"] = {
+                        {"content", {
+                            {
+                                {"type", "text"},
+                                {"text", "Echo: " + text}
+                            }
+                        }}
+                    };
+                } else if (tool_name == "time") {
+                    auto now = std::chrono::system_clock::now();
+                    auto time_t = std::chrono::system_clock::to_time_t(now);
+                    response["result"] = {
+                        {"content", {
+                            {
+                                {"type", "text"},
+                                {"text", std::ctime(&time_t)}
+                            }
+                        }}
+                    };
+                } else {
+                    response["error"] = {
+                        {"code", -32601},
+                        {"message", "Method not found: " + tool_name}
+                    };
+                }
+            } else if (method == "resources/list") {
+                response["result"] = {
+                    {"resources", json::array()}
+                };
+            } else {
+                response["error"] = {
+                    {"code", -32601},
+                    {"message", "Method not found: " + method}
+                };
+            }
+            
+            return response.dump();
+            
+        } catch (const std::exception& e) {
+            json error_response;
+            error_response["jsonrpc"] = "2.0";
+            error_response["id"] = json();
+            error_response["error"] = {
+                {"code", -32700},
+                {"message", "Parse error: " + std::string(e.what())}
+            };
+            return error_response.dump();
+        }
+    }
+};
+
+int main(int argc, char* argv[]) {
+    int port = 8080;
+    
+    if (argc > 1) {
+        port = std::atoi(argv[1]);
+    }
+    
+    SimpleTcpServer server(port);
+    
+    if (!server.start()) {
+        return 1;
+    }
+    
+    std::cout << "Press Ctrl+C to stop the server" << std::endl;
+    server.run();
+    
+    return 0;
+}


### PR DESCRIPTION
The original mcp_stdio_client tries to start and stop a local server. I would like to use the MCP client to instead talk to some server that is already running.  This adds support for allowing the client to contact a server at a given port and host.

Includes example code as well.

Code written by Claude. Seems to work, so far. Looks plausible to me.