### PR TITLE
Reproduce crash when calling stop() after non-blocking start

### DIFF
--- a/examples/server_example.cpp
+++ b/examples/server_example.cpp
@@ -171,7 +171,13 @@ int main() {
     // Start server
     std::cout << "Starting MCP server at localhost:8888..." << std::endl;
     std::cout << "Press Ctrl+C to stop the server" << std::endl;
-    server.start(true);  // Blocking mode
+    server.start(false);  // Unblocking mode
+
+    std::this_thread::sleep_for(std::chrono::seconds(5));
+
+    std::cout << "Stopping server..." << '\n';
+
+    server.stop();  // This will trigger a crash!
     
     return 0;
 } 

--- a/include/mcp_server.h
+++ b/include/mcp_server.h
@@ -398,6 +398,10 @@ private:
 
     // Close session
     void close_session(const std::string& session_id);
+
+    std::mutex maintenance_mutex_;
+    std::condition_variable maintenance_cv_;
+    bool stop_requested_ = false;
 };
 
 } // namespace mcp


### PR DESCRIPTION
This PR is only meant to demonstrate a crash scenario after calling `stop()` on a non-blocking server.

Please feel free to use this for debugging or reproduction — **not intended for merge**.
