### PR TITLE
Ensures that the maintenance thread always starts.

### DIFF
--- a/include/mcp_server.h
+++ b/include/mcp_server.h
@@ -429,7 +429,11 @@ private:
 
     // Session management and maintenance
     void check_inactive_sessions();
+
+    std::mutex maintenance_mutex_;
+    std::condition_variable maintenance_cond_;
     std::unique_ptr<std::thread> maintenance_thread_;
+    bool maintenance_thread_run_ = false;
 
     // Session cleanup handler
     std::map<std::string, session_cleanup_handler> session_cleanup_handler_;


### PR DESCRIPTION
Make sure that the maintenance thread starts when background mode is set to true. Use a condition variable instead of sleep so you don't have to wait for the maintenance thread to finish a sleep interval when shutting down the server.

Fixes #31