### PR TITLE
Fix the issue where std::localtime() fails to compile in msvc without defining _CRT_SECURE_NO_WARNINGS

### DIFF
--- a/include/mcp_logger.h
+++ b/include/mcp_logger.h
@@ -79,8 +79,18 @@ private:
         // Add timestamp
         auto now = std::chrono::system_clock::now();
         auto now_c = std::chrono::system_clock::to_time_t(now);
+#if _CRT_SECURE_NO_WARNINGS
         auto now_tm = std::localtime(&now_c);
-        
+#else
+        std::tm _tm;
+#   ifdef _WIN32
+        localtime_s(&_tm, &now_c);
+#   else
+        localtime_r(&now_c, &_tm);
+#   endif
+        tm* now_tm = &_tm;
+#endif
+
         ss << std::put_time(now_tm, "%Y-%m-%d %H:%M:%S") << " ";
         
         // Add log level and color

--- a/src/mcp_stdio_client.cpp
+++ b/src/mcp_stdio_client.cpp
@@ -646,6 +646,7 @@ void stdio_client::read_thread_func() {
                             }
                         }
                     } catch (const json::exception& e) {
+                        (e);
                         LOG_INFO("message: ", line);
                     }
                 }


### PR DESCRIPTION
Fix the issue where std::localtime() fails to compile in msvc without defining _CRT_SECURE_NO_WARNINGS
修改 std::localtime() 在没有定义 _CRT_SECURE_NO_WARNINGS 下msvc编译失败的问题