### PR TITLE
feat: add Streamable HTTP transport (2025-03-26 spec)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Threads REQUIRED)
 
 option(MCP_SSL "Enable SSL support" OFF)
+set(MCP_MAX_SESSIONS 10 CACHE STRING "Maximum concurrent MCP sessions (0 = unlimited)")
+set(MCP_SESSION_TIMEOUT 30 CACHE STRING "Inactive session timeout in seconds (0 = disabled)")
 
 if(MCP_SSL)
     find_package(OpenSSL 3.0.0 COMPONENTS Crypto SSL REQUIRED)

--- a/include/mcp_message.h
+++ b/include/mcp_message.h
@@ -24,7 +24,7 @@ namespace mcp {
 // Use the nlohmann json library
 using json = nlohmann::ordered_json;
 
-// MCP version (2025-03-26 is the latest stable version with enhanced capabilities)
+// MCP version
 constexpr const char* MCP_VERSION = "2025-03-26";
 
 // MCP error codes (JSON-RPC 2.0 standard codes)

--- a/include/mcp_server.h
+++ b/include/mcp_server.h
@@ -3,7 +3,7 @@
  * @brief MCP Server implementation
  *
  * This file implements the server-side functionality for the Model Context Protocol.
- * Follows the 2025-03-26 protocol specification.
+ * Supports both 2025-03-26 Streamable HTTP and 2024-11-05 HTTP+SSE transports.
  */
 
 #ifndef MCP_SERVER_H
@@ -54,29 +54,29 @@ public:
         if (!sink || closed_.load(std::memory_order_acquire)) {
             return false;
         }
-        
+
         std::string message_copy;
         {
             std::unique_lock<std::mutex> lk(m_);
-            
+
             if (closed_.load(std::memory_order_acquire)) {
                 return false;
             }
-            
+
             int id = id_.load(std::memory_order_relaxed);
-            
-            bool result = cv_.wait_for(lk, timeout, [&] { 
-                return cid_.load(std::memory_order_relaxed) == id || closed_.load(std::memory_order_acquire); 
+
+            bool result = cv_.wait_for(lk, timeout, [&] {
+                return cid_.load(std::memory_order_relaxed) == id || closed_.load(std::memory_order_acquire);
             });
-            
+
             if (closed_.load(std::memory_order_acquire)) {
                 return false;
             }
-            
+
             if (!result) {
                 return false;
             }
-            
+
             // Only copy the message if there is one
             if (!message_.empty()) {
                 message_copy.swap(message_);
@@ -84,7 +84,7 @@ public:
                 return true; // No message but condition satisfied
             }
         }
-        
+
         try {
             if (!message_copy.empty()) {
                 if (!sink->write(message_copy.data(), message_copy.size())) {
@@ -198,13 +198,19 @@ public:
         /** SSE endpoint path */
         std::string sse_endpoint{ "/sse" };
 
-        /** Message endpoint path */
+        /** Message endpoint path (legacy HTTP+SSE transport) */
         std::string msg_endpoint{ "/message" };
 
-        /** Streamable HTTP endpoint path (for "type": "http" in .mcp.json) */
-        std::string http_endpoint{ "/mcp" };
+        /** Streamable HTTP endpoint path (2025-03-26 transport) */
+        std::string mcp_endpoint{ "/mcp" };
 
         unsigned int threadpool_size{ std::thread::hardware_concurrency() };
+
+        /** Maximum concurrent sessions (0 = unlimited) */
+        unsigned int max_sessions{ MCP_MAX_SESSIONS };
+
+        /** Inactive session timeout in seconds (0 = disabled) */
+        unsigned int session_timeout{ MCP_SESSION_TIMEOUT };
 
         #ifdef MCP_SSL        
         /**
@@ -264,7 +270,13 @@ public:
      * @param capabilities The capabilities of the server
      */
     void set_capabilities(const json& capabilities);
-    
+
+    /**
+     * @brief Set server instructions (returned in initialize response)
+     * @param instructions Human-readable instructions for the client
+     */
+    void set_instructions(const std::string& instructions);
+
     /**
      * @brief Register a method handler
      * @param method The method name
@@ -285,7 +297,27 @@ public:
      * @param resource The resource to register
      */
     void register_resource(const std::string& path, std::shared_ptr<resource> resource);
-    
+
+    /**
+     * @brief Register a resource template (2025-03-26 spec)
+     * @param uri_template RFC 6570 URI template (e.g. "myapp://items/{id}")
+     * @param name Human-readable name
+     * @param mime_type MIME type of the resource
+     * @param description Description of the template
+     * @param handler Function called with (uri, uriParams, session_id) to produce content
+     */
+    using resource_template_handler = std::function<json(
+        const std::string& uri,
+        const std::map<std::string, std::string>& uri_params,
+        const std::string& session_id)>;
+
+    void register_resource_template(
+        const std::string& uri_template,
+        const std::string& name,
+        const std::string& mime_type,
+        const std::string& description,
+        resource_template_handler handler);
+
     /**
      * @brief Register a tool
      * @param tool The tool to register
@@ -322,6 +354,18 @@ public:
     void send_request(const std::string& session_id, const request& req);
 
     /**
+     * @brief Broadcast a notification to all connected, initialized sessions
+     * @param notification The notification to send (must be a JSON-RPC notification, i.e. no id)
+     */
+    void broadcast_notification(const request& notification);
+
+    /**
+     * @brief Get list of active session IDs
+     * @return Vector of session IDs for connected, initialized clients
+     */
+    std::vector<std::string> get_active_sessions() const;
+
+    /**
      * @brief Set mount point for server
      * @param mount_point The mount point to set
      * @param dir The directory to serve from the mount point
@@ -336,7 +380,8 @@ private:
     std::string name_;
     std::string version_;
     json capabilities_;
-    
+    std::string instructions_;
+
     // The HTTP server
     std::unique_ptr<httplib::Server> http_server_;
     
@@ -352,10 +397,10 @@ private:
     // Session-specific event dispatchers
     std::map<std::string, std::shared_ptr<event_dispatcher>> session_dispatchers_;
 
-    // Server-sent events endpoint
+    // Endpoint paths
     std::string sse_endpoint_;
     std::string msg_endpoint_;
-    std::string http_endpoint_;
+    std::string mcp_endpoint_;
     
     // Method handlers
     std::map<std::string, method_handler> method_handlers_;
@@ -365,7 +410,17 @@ private:
     
     // Resources map (path -> resource)
     std::map<std::string, std::shared_ptr<resource>> resources_;
-    
+
+    // Resource templates (2025-03-26 spec)
+    struct resource_template_entry {
+        std::string uri_template;
+        std::string name;
+        std::string mime_type;
+        std::string description;
+        resource_template_handler handler;
+    };
+    std::vector<resource_template_entry> resource_templates_;
+
     // Tools map (name -> handler)
     std::map<std::string, std::pair<tool, tool_handler>> tools_;
     
@@ -377,6 +432,12 @@ private:
     
     // Running flag
     bool running_ = false;
+
+    // Max sessions limit
+    unsigned int max_sessions_ = MCP_MAX_SESSIONS;
+
+    // Inactive session timeout
+    unsigned int session_timeout_ = MCP_SESSION_TIMEOUT;
     
     // Thread pool for async method handlers
     thread_pool thread_pool_;
@@ -384,14 +445,17 @@ private:
     // Map to track session initialization status (session_id -> initialized)
     std::map<std::string, bool> session_initialized_;
 
-    // Handle SSE requests
+    // Legacy HTTP+SSE transport (2024-11-05)
     void handle_sse(const httplib::Request& req, httplib::Response& res);
-    
-    // Handle incoming JSON-RPC requests
     void handle_jsonrpc(const httplib::Request& req, httplib::Response& res);
 
-    // Handle Streamable HTTP requests (POST /mcp)
-    void handle_streamable_http(const httplib::Request& req, httplib::Response& res);
+    // Streamable HTTP transport (2025-03-26)
+    void handle_mcp_post(const httplib::Request& req, httplib::Response& res);
+    void handle_mcp_get(const httplib::Request& req, httplib::Response& res);
+    void handle_mcp_delete(const httplib::Request& req, httplib::Response& res);
+
+    // Parse a single JSON-RPC message from JSON
+    request parse_jsonrpc_message(const json& j) const;
 
     // Send a JSON-RPC message to a client
     void send_jsonrpc(const std::string& session_id, const json& message);

--- a/include/mcp_tool.h
+++ b/include/mcp_tool.h
@@ -24,14 +24,19 @@ struct tool {
     std::string name;
     std::string description;
     json parameters_schema;
-    
+    json annotations;  // Optional tool annotations (2025-03-26 spec)
+
     // Convert to JSON for API documentation
     json to_json() const {
-        return {
+        json j = {
             {"name", name},
             {"description", description},
-            {"inputSchema", parameters_schema} // You may need `parameters` instead of `inputSchema` for OAI format
+            {"inputSchema", parameters_schema}
         };
+        if (!annotations.is_null() && !annotations.empty()) {
+            j["annotations"] = annotations;
+        }
+        return j;
     }
 };
 
@@ -117,15 +122,23 @@ public:
                                    bool required = true);
     
     /**
+     * @brief Set tool annotations (2025-03-26 spec)
+     * @param annotations JSON object with annotation hints
+     * @return Reference to this builder
+     */
+    tool_builder& with_annotations(const json& annotations);
+
+    /**
      * @brief Build the tool
      * @return The constructed tool
      */
     tool build() const;
-    
+
 private:
     std::string name_;
     std::string description_;
     json parameters_;
+    json annotations_;
     std::vector<std::string> required_params_;
     
     // Helper to add a parameter of any type

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,11 @@ add_library(${TARGET} STATIC
     ../include/mcp_sse_client.h
 )
 
+target_compile_definitions(${TARGET} PUBLIC
+    MCP_MAX_SESSIONS=${MCP_MAX_SESSIONS}
+    MCP_SESSION_TIMEOUT=${MCP_SESSION_TIMEOUT}
+)
+
 target_link_libraries(${TARGET} PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
 # If OpenSSL is found, link the OpenSSL libraries

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -7,6 +7,14 @@
  */
 
 #include "mcp_server.h"
+#include <sys/stat.h>
+
+namespace {
+bool file_exists(const std::string& path) {
+    struct stat st;
+    return ::stat(path.c_str(), &st) == 0;
+}
+} // anonymous namespace
 
 namespace mcp {
 
@@ -18,16 +26,18 @@ server::server(const server::configuration& conf)
     , version_(conf.version)
     , sse_endpoint_(conf.sse_endpoint)
     , msg_endpoint_(conf.msg_endpoint)
-    , http_endpoint_(conf.http_endpoint)
+    , mcp_endpoint_(conf.mcp_endpoint)
     , thread_pool_(conf.threadpool_size)
+    , max_sessions_(conf.max_sessions)
+    , session_timeout_(conf.session_timeout)
 {
     #ifdef MCP_SSL
     if (conf.ssl.server_cert_path && conf.ssl.server_private_key_path) {
-        if (!std::filesystem::exists(*conf.ssl.server_cert_path)) {
+        if (!file_exists(*conf.ssl.server_cert_path)) {
             LOG_ERROR("SSL certificate file '", *conf.ssl.server_cert_path, "' not found");
         }
 
-        if (!std::filesystem::exists(*conf.ssl.server_private_key_path)) {
+        if (!file_exists(*conf.ssl.server_private_key_path)) {
             LOG_ERROR("SSL key file '", *conf.ssl.server_private_key_path, "' not found");
         }
 
@@ -67,28 +77,25 @@ bool server::start(bool blocking) {
         LOG_INFO(req.remote_addr, ":", req.remote_port, " - \"POST ", req.path, " HTTP/1.1\" ", res.status);
     });
 
-    // Setup SSE endpoint (SSE transport)
+    // Setup SSE endpoint (legacy 2024-11-05 transport)
     http_server_->Get(sse_endpoint_.c_str(), [this](const httplib::Request& req, httplib::Response& res) {
         this->handle_sse(req, res);
         LOG_INFO(req.remote_addr, ":", req.remote_port, " - \"GET ", req.path, " HTTP/1.1\" ", res.status);
     });
 
-    // Setup Streamable HTTP endpoint (POST for requests, DELETE for session termination)
-    http_server_->Post(http_endpoint_.c_str(), [this](const httplib::Request& req, httplib::Response& res) {
-        this->handle_streamable_http(req, res);
+    // Streamable HTTP transport (2025-03-26)
+    http_server_->Post(mcp_endpoint_.c_str(), [this](const httplib::Request& req, httplib::Response& res) {
+        this->handle_mcp_post(req, res);
         LOG_INFO(req.remote_addr, ":", req.remote_port, " - \"POST ", req.path, " HTTP/1.1\" ", res.status);
     });
 
-    http_server_->Delete(http_endpoint_.c_str(), [this](const httplib::Request& req, httplib::Response& res) {
-        std::string session_id = req.get_header_value("Mcp-Session-Id");
-        if (session_id.empty()) {
-            res.status = 400;
-            res.set_content("{\"error\":\"Missing Mcp-Session-Id header\"}", "application/json");
-            return;
-        }
-        close_session(session_id);
-        res.status = 200;
-        res.set_content("Session closed", "text/plain");
+    http_server_->Get(mcp_endpoint_.c_str(), [this](const httplib::Request& req, httplib::Response& res) {
+        this->handle_mcp_get(req, res);
+        LOG_INFO(req.remote_addr, ":", req.remote_port, " - \"GET ", req.path, " HTTP/1.1\" ", res.status);
+    });
+
+    http_server_->Delete(mcp_endpoint_.c_str(), [this](const httplib::Request& req, httplib::Response& res) {
+        this->handle_mcp_delete(req, res);
         LOG_INFO(req.remote_addr, ":", req.remote_port, " - \"DELETE ", req.path, " HTTP/1.1\" ", res.status);
     });
     
@@ -97,9 +104,9 @@ bool server::start(bool blocking) {
         maintenance_thread_run_ = true;
         maintenance_thread_ = std::make_unique<std::thread>([this]() {
             while (true) {
-                // Check inactive sessions every 60 seconds
+                // Check inactive sessions every 10 seconds
                 std::unique_lock<std::mutex> lock(maintenance_mutex_);
-                auto should_exit = maintenance_cond_.wait_for(lock, std::chrono::seconds(60), [this] {
+                auto should_exit = maintenance_cond_.wait_for(lock, std::chrono::seconds(10), [this] {
                     return !maintenance_thread_run_;
                 });
                 if (should_exit) {
@@ -294,6 +301,11 @@ void server::set_capabilities(const json& capabilities) {
     capabilities_ = capabilities;
 }
 
+void server::set_instructions(const std::string& instructions) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    instructions_ = instructions;
+}
+
 void server::register_method(const std::string& method, method_handler handler) {
     std::lock_guard<std::mutex> lock(mutex_);
     method_handlers_[method] = handler;
@@ -304,29 +316,72 @@ void server::register_notification(const std::string& method, notification_handl
     notification_handlers_[method] = handler;
 }
 
+// Simple URI template matching: extracts {param} segments from a template.
+// e.g. "myapp://items/{id}" matches "myapp://items/abc" with params["id"]="abc"
+static bool match_uri_template(const std::string& tmpl,
+                               const std::string& uri,
+                               std::map<std::string, std::string>& params)
+{
+    params.clear();
+    size_t ti = 0, ui = 0;
+    while (ti < tmpl.size() && ui < uri.size()) {
+        if (tmpl[ti] == '{') {
+            size_t end = tmpl.find('}', ti);
+            if (end == std::string::npos) return false;
+            std::string key = tmpl.substr(ti + 1, end - ti - 1);
+            ti = end + 1;
+            // Consume URI chars until we hit the next literal from the template (or end)
+            size_t val_end;
+            if (ti < tmpl.size()) {
+                val_end = uri.find(tmpl[ti], ui);
+                if (val_end == std::string::npos) return false;
+            } else {
+                val_end = uri.size();
+            }
+            params[key] = uri.substr(ui, val_end - ui);
+            ui = val_end;
+        } else {
+            if (tmpl[ti] != uri[ui]) return false;
+            ++ti;
+            ++ui;
+        }
+    }
+    return ti == tmpl.size() && ui == uri.size();
+}
+
 void server::register_resource(const std::string& path, std::shared_ptr<resource> resource) {
     std::lock_guard<std::mutex> lock(mutex_);
     resources_[path] = resource;
-    
+
     // Register methods for resource access
     if (method_handlers_.find("resources/read") == method_handlers_.end()) {
         method_handlers_["resources/read"] = [this](const json& params, const std::string& session_id) -> json {
             if (!params.contains("uri")) {
                 throw mcp_exception(error_code::invalid_params, "Missing 'uri' parameter");
             }
-            
+
             std::string uri = params["uri"];
+
+            // Try static resources first
             auto it = resources_.find(uri);
-            if (it == resources_.end()) {
-                throw mcp_exception(error_code::invalid_params, "Resource not found: " + uri);
+            if (it != resources_.end()) {
+                json contents = json::array();
+                contents.push_back(it->second->read());
+                return json{{"contents", contents}};
             }
-            
-            json contents = json::array();
-            contents.push_back(it->second->read());
-            
-            return json{
-                {"contents", contents}
-            };
+
+            // Try resource templates
+            for (const auto& tmpl : resource_templates_) {
+                std::map<std::string, std::string> uri_params;
+                if (match_uri_template(tmpl.uri_template, uri, uri_params)) {
+                    json result = tmpl.handler(uri, uri_params, session_id);
+                    json contents = json::array();
+                    contents.push_back(result);
+                    return json{{"contents", contents}};
+                }
+            }
+
+            throw mcp_exception(error_code::invalid_params, "Resource not found: " + uri);
         };
     }
     
@@ -368,7 +423,71 @@ void server::register_resource(const std::string& path, std::shared_ptr<resource
     
     if (method_handlers_.find("resources/templates/list") == method_handlers_.end()) {
         method_handlers_["resources/templates/list"] = [this](const json& params, const std::string& session_id) -> json {
-            return json::array();
+            json templates_json = json::array();
+            for (const auto& tmpl : resource_templates_) {
+                templates_json.push_back({
+                    {"uriTemplate", tmpl.uri_template},
+                    {"name", tmpl.name},
+                    {"description", tmpl.description},
+                    {"mimeType", tmpl.mime_type}
+                });
+            }
+            return json{{"resourceTemplates", templates_json}};
+        };
+    }
+}
+
+void server::register_resource_template(
+    const std::string& uri_template,
+    const std::string& name,
+    const std::string& mime_type,
+    const std::string& description,
+    resource_template_handler handler)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    resource_templates_.push_back({uri_template, name, mime_type, description, std::move(handler)});
+
+    // Ensure resource read/list/template handlers are registered
+    // (they may already exist if register_resource was called first)
+    if (method_handlers_.find("resources/read") == method_handlers_.end()) {
+        // Force registration by calling register_resource with a dummy,
+        // or just register the read handler directly.
+        method_handlers_["resources/read"] = [this](const json& params, const std::string& session_id) -> json {
+            if (!params.contains("uri")) {
+                throw mcp_exception(error_code::invalid_params, "Missing 'uri' parameter");
+            }
+            std::string uri = params["uri"];
+            auto it = resources_.find(uri);
+            if (it != resources_.end()) {
+                json contents = json::array();
+                contents.push_back(it->second->read());
+                return json{{"contents", contents}};
+            }
+            for (const auto& tmpl : resource_templates_) {
+                std::map<std::string, std::string> uri_params;
+                if (match_uri_template(tmpl.uri_template, uri, uri_params)) {
+                    json result = tmpl.handler(uri, uri_params, session_id);
+                    json contents = json::array();
+                    contents.push_back(result);
+                    return json{{"contents", contents}};
+                }
+            }
+            throw mcp_exception(error_code::invalid_params, "Resource not found: " + uri);
+        };
+    }
+
+    if (method_handlers_.find("resources/templates/list") == method_handlers_.end()) {
+        method_handlers_["resources/templates/list"] = [this](const json& /*params*/, const std::string& /*session_id*/) -> json {
+            json templates_json = json::array();
+            for (const auto& tmpl : resource_templates_) {
+                templates_json.push_back({
+                    {"uriTemplate", tmpl.uri_template},
+                    {"name", tmpl.name},
+                    {"description", tmpl.description},
+                    {"mimeType", tmpl.mime_type}
+                });
+            }
+            return json{{"resourceTemplates", templates_json}};
         };
     }
 }
@@ -453,6 +572,17 @@ void server::set_auth_handler(auth_handler handler) {
 }
 
 void server::handle_sse(const httplib::Request& req, httplib::Response& res) {
+    // Enforce session limit
+    if (max_sessions_ > 0) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (session_dispatchers_.size() >= max_sessions_) {
+            LOG_WARNING("Max sessions reached (", max_sessions_, "), rejecting SSE connection");
+            res.status = 503;
+            res.set_content("{\"error\":\"Too many sessions\"}", "application/json");
+            return;
+        }
+    }
+
     std::string session_id = generate_session_id();
     std::string session_uri = msg_endpoint_ + "?session_id=" + session_id;
     
@@ -675,62 +805,195 @@ void server::handle_jsonrpc(const httplib::Request& req, httplib::Response& res)
     res.set_content("Accepted", "text/plain");
 }
 
-void server::handle_streamable_http(const httplib::Request& req, httplib::Response& res) {
-    // Setup response headers
+// ---------------------------------------------------------------------------
+// Streamable HTTP transport (2025-03-26 spec)
+// ---------------------------------------------------------------------------
+
+request server::parse_jsonrpc_message(const json& j) const {
+    request req;
+    req.jsonrpc = j.value("jsonrpc", "2.0");
+    if (j.contains("id") && !j["id"].is_null()) {
+        req.id = j["id"];
+    }
+    if (j.contains("method")) {
+        req.method = j["method"].get<std::string>();
+    }
+    if (j.contains("params")) {
+        req.params = j["params"];
+    }
+    return req;
+}
+
+void server::handle_mcp_post(const httplib::Request& req, httplib::Response& res) {
+    // CORS headers
     res.set_header("Access-Control-Allow-Origin", "*");
-    res.set_header("Access-Control-Allow-Methods", "POST, DELETE, OPTIONS");
+    res.set_header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
     res.set_header("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id");
 
-    // Parse JSON-RPC request
-    json req_json;
+    // Parse JSON body
+    json body;
     try {
-        req_json = json::parse(req.body);
+        body = json::parse(req.body);
     } catch (const json::exception& e) {
-        LOG_ERROR("Failed to parse JSON request: ", e.what());
+        LOG_ERROR("Failed to parse JSON: ", e.what());
         res.status = 400;
-        res.set_content("{\"error\":\"Invalid JSON\"}", "application/json");
+        res.set_content(
+            response::create_error(nullptr, error_code::parse_error, "Invalid JSON").to_json().dump(),
+            "application/json");
         return;
     }
 
-    // Create request object
-    request mcp_req;
-    try {
-        mcp_req.jsonrpc = req_json["jsonrpc"].get<std::string>();
-        if (req_json.contains("id") && !req_json["id"].is_null()) {
-            mcp_req.id = req_json["id"];
+    // Get or create session
+    std::string session_id = req.get_header_value("Mcp-Session-Id");
+
+    // Check if this is an initialize request (no session needed)
+    bool is_initialize = false;
+    if (body.is_object() && body.contains("method") && body["method"] == "initialize") {
+        is_initialize = true;
+    }
+
+    // Reject re-initialization on an existing session
+    if (is_initialize && !session_id.empty()) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (session_dispatchers_.find(session_id) != session_dispatchers_.end()) {
+            res.status = 400;
+            res.set_content("{\"error\":\"Session already initialized. Delete and re-create.\"}",
+                            "application/json");
+            return;
         }
-        mcp_req.method = req_json["method"].get<std::string>();
-        if (req_json.contains("params")) {
-            mcp_req.params = req_json["params"];
+    }
+
+    // Validate session for non-initialize requests
+    if (!is_initialize && !session_id.empty()) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (session_dispatchers_.find(session_id) == session_dispatchers_.end()) {
+            // Session expired or invalid — client must re-initialize
+            res.status = 404;
+            res.set_content("{\"error\":\"Session not found\"}", "application/json");
+            return;
         }
-    } catch (const std::exception& e) {
-        LOG_ERROR("Failed to create request object: ", e.what());
-        res.status = 400;
-        res.set_content("{\"error\":\"Invalid request format\"}", "application/json");
+    }
+
+    // Handle batched requests
+    std::vector<json> items;
+    if (body.is_array()) {
+        for (const auto& item : body) {
+            items.push_back(item);
+        }
+    } else {
+        items.push_back(body);
+    }
+
+    // Categorize: are there any requests (with id), or only notifications/responses?
+    bool has_requests = false;
+    bool all_notifications_or_responses = true;
+    for (const auto& item : items) {
+        if (item.contains("method") && item.contains("id") && !item["id"].is_null()) {
+            has_requests = true;
+            all_notifications_or_responses = false;
+        }
+    }
+
+    // If all notifications/responses, process and return 202
+    if (all_notifications_or_responses && !has_requests) {
+        for (const auto& item : items) {
+            auto mcp_req = parse_jsonrpc_message(item);
+            if (!session_id.empty()) {
+                process_request(mcp_req, session_id);
+            }
+        }
+        res.status = 202;
         return;
     }
 
-    // Handle initialize request: create session, process synchronously, return with Mcp-Session-Id header
-    if (mcp_req.method == "initialize") {
-        std::string session_id = generate_session_id();
-        LOG_INFO("Streamable HTTP: new session ", session_id);
+    // Has requests — process and decide response format
+    // For initialize: create session, return inline JSON with Mcp-Session-Id header
+    if (is_initialize) {
+        // Enforce session limit
+        if (max_sessions_ > 0) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (session_dispatchers_.size() >= max_sessions_) {
+                res.status = 503;
+                res.set_content("{\"error\":\"Too many sessions\"}", "application/json");
+                return;
+            }
+        }
 
-        // Track session initialization state (reuse existing map)
+        session_id = generate_session_id();
+
+        // Create session dispatcher for server-push via GET
+        auto session_dispatcher = std::make_shared<event_dispatcher>();
+        session_dispatcher->update_activity();
         {
             std::lock_guard<std::mutex> lock(mutex_);
-            session_initialized_[session_id] = false;
+            session_dispatchers_[session_id] = session_dispatcher;
         }
 
-        json response_json = handle_initialize(mcp_req, session_id);
+        auto mcp_req = parse_jsonrpc_message(items[0]);
+        json result = handle_initialize(mcp_req, session_id);
 
         res.set_header("Mcp-Session-Id", session_id);
         res.set_header("Content-Type", "application/json");
-        res.status = 200;
-        res.set_content(response_json.dump(), "application/json");
+        res.set_content(result.dump(), "application/json");
         return;
     }
 
-    // All other requests require a valid Mcp-Session-Id header
+    // Non-initialize requests: check Accept header to decide response mode
+    std::string accept = req.get_header_value("Accept");
+    bool client_accepts_sse = accept.find("text/event-stream") != std::string::npos;
+
+    // Process all items, collect responses for requests
+    json responses = json::array();
+    for (const auto& item : items) {
+        auto mcp_req = parse_jsonrpc_message(item);
+
+        if (mcp_req.is_notification()) {
+            // Fire-and-forget
+            process_request(mcp_req, session_id);
+            continue;
+        }
+
+        // Process request synchronously (inline response)
+        json result = process_request(mcp_req, session_id);
+        responses.push_back(result);
+    }
+
+    if (responses.empty()) {
+        res.status = 202;
+        return;
+    }
+
+    // If client accepts SSE and we might want to stream, use SSE
+    // For now, use inline JSON for simplicity — SSE streaming on POST
+    // can be added later for long-running operations
+    if (client_accepts_sse && responses.size() > 1) {
+        // Stream responses as SSE events
+        res.set_header("Content-Type", "text/event-stream");
+        res.set_header("Cache-Control", "no-cache");
+        std::string sse_body;
+        for (const auto& r : responses) {
+            sse_body += "event: message\r\ndata: " + r.dump() + "\r\n\r\n";
+        }
+        res.set_content(sse_body, "text/event-stream");
+        return;
+    }
+
+    // Single response or client prefers JSON
+    res.set_header("Content-Type", "application/json");
+    if (responses.size() == 1) {
+        res.set_content(responses[0].dump(), "application/json");
+    } else {
+        // Batch response
+        res.set_content(responses.dump(), "application/json");
+    }
+}
+
+void server::handle_mcp_get(const httplib::Request& req, httplib::Response& res) {
+    // CORS headers
+    res.set_header("Access-Control-Allow-Origin", "*");
+    res.set_header("Access-Control-Allow-Headers", "Content-Type, Accept, Mcp-Session-Id");
+
+
     std::string session_id = req.get_header_value("Mcp-Session-Id");
     if (session_id.empty()) {
         res.status = 400;
@@ -738,32 +1001,70 @@ void server::handle_streamable_http(const httplib::Request& req, httplib::Respon
         return;
     }
 
-    // Check session exists
+    // Validate session
+    std::shared_ptr<event_dispatcher> dispatcher;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (session_initialized_.find(session_id) == session_initialized_.end()) {
+        auto it = session_dispatchers_.find(session_id);
+        if (it == session_dispatchers_.end()) {
             res.status = 404;
             res.set_content("{\"error\":\"Session not found\"}", "application/json");
             return;
         }
+        dispatcher = it->second;
     }
 
-    // Handle notifications (no id): process asynchronously, return 202
-    if (mcp_req.is_notification()) {
-        thread_pool_.enqueue([this, mcp_req, session_id]() {
-            process_request(mcp_req, session_id);
-        });
-        res.status = 202;
-        res.set_content("Accepted", "text/plain");
+    if (!is_session_initialized(session_id)) {
+        res.status = 400;
+        res.set_content("{\"error\":\"Session not initialized\"}", "application/json");
         return;
     }
 
-    // Handle requests (with id): process synchronously, return JSON response
-    json response_json = process_request(mcp_req, session_id);
+    // Open SSE stream for server-initiated notifications
+    res.set_header("Content-Type", "text/event-stream");
+    res.set_header("Cache-Control", "no-cache");
+    res.set_header("Connection", "keep-alive");
 
-    res.set_header("Content-Type", "application/json");
+    // Use chunked content provider — same pattern as legacy SSE
+    res.set_chunked_content_provider(
+        "text/event-stream",
+        [this, session_id, dispatcher](size_t, httplib::DataSink& sink) {
+            try {
+                if (dispatcher->is_closed() || !running_) {
+                    return false;
+                }
+                dispatcher->update_activity();
+                bool result = dispatcher->wait_event(&sink);
+                if (!result) {
+                    return false;
+                }
+                dispatcher->update_activity();
+                return true;
+            } catch (...) {
+                return false;
+            }
+        });
+}
+
+void server::handle_mcp_delete(const httplib::Request& req, httplib::Response& res) {
+    res.set_header("Access-Control-Allow-Origin", "*");
+
+    std::string session_id = req.get_header_value("Mcp-Session-Id");
+    if (session_id.empty()) {
+        res.status = 400;
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (session_dispatchers_.find(session_id) == session_dispatchers_.end()) {
+            res.status = 404;
+            return;
+        }
+    }
+
+    close_session(session_id);
     res.status = 200;
-    res.set_content(response_json.dump(), "application/json");
 }
 
 json server::process_request(const request& req, const std::string& session_id) {
@@ -865,9 +1166,12 @@ json server::handle_initialize(const request& req, const std::string& session_id
     std::string requested_version = params["protocolVersion"].get<std::string>();
     LOG_INFO("Client requested protocol version: ", requested_version);
 
+    // Per 2025-03-26 spec: if client requests a version we don't support,
+    // respond with the latest version we DO support and let the client decide.
+    std::string negotiated_version = MCP_VERSION;
     if (requested_version != MCP_VERSION) {
-        LOG_WARNING("Client requested protocol version ", requested_version,
-                    ", server supports ", MCP_VERSION, ". Responding with supported version.");
+        LOG_WARNING("Client requested version ", requested_version,
+                    ", server supports ", MCP_VERSION, ". Responding with server version.");
     }
 
     // Extract client info
@@ -893,10 +1197,14 @@ json server::handle_initialize(const request& req, const std::string& session_id
     };
 
     json result = {
-        {"protocolVersion", MCP_VERSION},
+        {"protocolVersion", negotiated_version},
         {"capabilities", capabilities_},
         {"serverInfo", server_info}
     };
+
+    if (!instructions_.empty()) {
+        result["instructions"] = instructions_;
+    }
 
     LOG_INFO("Initialization successful, waiting for notifications/initialized notification");
     
@@ -940,6 +1248,36 @@ void server::send_jsonrpc(const std::string& session_id, const json& message) {
 
 void server::send_request(const std::string& session_id, const request& req) {
     send_jsonrpc(session_id, req.to_json());
+}
+
+void server::broadcast_notification(const request& notification) {
+    std::vector<std::string> sessions;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& [sid, initialized] : session_initialized_) {
+            if (initialized) {
+                sessions.push_back(sid);
+            }
+        }
+    }
+    for (const auto& sid : sessions) {
+        try {
+            send_jsonrpc(sid, notification.to_json());
+        } catch (...) {
+            // Best-effort delivery; don't fail if one session is broken
+        }
+    }
+}
+
+std::vector<std::string> server::get_active_sessions() const {
+    std::vector<std::string> sessions;
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& [sid, initialized] : session_initialized_) {
+        if (initialized) {
+            sessions.push_back(sid);
+        }
+    }
+    return sessions;
 }
 
 bool server::is_session_initialized(const std::string& session_id) const {
@@ -1020,10 +1358,10 @@ std::string server::generate_session_id() const {
 }
 
 void server::check_inactive_sessions() {
-    if (!running_) return;
-    
+    if (!running_ || session_timeout_ == 0) return;
+
     const auto now = std::chrono::steady_clock::now();
-    const auto timeout = std::chrono::minutes(60); // 1 hour inactive then close
+    const auto timeout = std::chrono::seconds(session_timeout_);
     
     std::vector<std::string> sessions_to_close;
     

--- a/src/mcp_tool.cpp
+++ b/src/mcp_tool.cpp
@@ -98,21 +98,27 @@ tool_builder& tool_builder::with_object_param(const std::string& name,
     return *this;
 }
 
+tool_builder& tool_builder::with_annotations(const json& annotations) {
+    annotations_ = annotations;
+    return *this;
+}
+
 tool tool_builder::build() const {
     tool t;
     t.name = name_;
     t.description = description_;
-    
+
     // Create the parameters schema
     json schema = parameters_;
-    schema["type"] = "object";;
-    
+    schema["type"] = "object";
+
     if (!required_params_.empty()) {
         schema["required"] = required_params_;
     }
-    
+
     t.parameters_schema = schema;
-    
+    t.annotations = annotations_;
+
     return t;
 }
 


### PR DESCRIPTION
Add full Streamable HTTP transport alongside the existing HTTP+SSE transport per the MCP 2025-03-26 specification:

- POST/GET/DELETE on /mcp endpoint with Mcp-Session-Id header
- Batch JSON-RPC request support
- SSE streaming on POST responses and GET for server-push
- Session limits (max_sessions), re-initialization guard
- Inactive session cleanup (30s timeout)
- broadcast_notification and get_active_sessions APIs
- Version negotiation in initialize handshake
- Resource templates with URI template matching