### PR TITLE
feat: Upgrade thread pool to support dynamic scaling and prevent task starvation

### DIFF
--- a/include/mcp_thread_pool.h
+++ b/include/mcp_thread_pool.h
@@ -1,12 +1,11 @@
 /**
  * @file mcp_thread_pool.h
- * @brief Simple thread pool implementation
+ * @brief Dynamic thread pool implementation
  */
 
 #ifndef MCP_THREAD_POOL_H
 #define MCP_THREAD_POOL_H
 
-#include <vector>
 #include <queue>
 #include <thread>
 #include <mutex>
@@ -15,38 +14,34 @@
 #include <future>
 #include <atomic>
 #include <type_traits>
+#include <chrono>
+#include <stdexcept>
 
 namespace mcp {
 
 class thread_pool {
 public:
     /**
-     * @brief Constructor
-     * @param num_threads Number of threads in the thread pool
+     * @brief Constructor for dynamic thread pool
+     * @param min_threads Minimum number of threads (core threads)
+     * @param max_threads Maximum number of threads
+     * @param idle_timeout_ms Idle time in milliseconds before a thread exits
      */
-    explicit thread_pool(unsigned int num_threads = std::thread::hardware_concurrency()) : stop_(false) {
-        for (unsigned int i = 0; i < num_threads; ++i) {
-            workers_.emplace_back([this] {
-                while (true) {
-                    std::function<void()> task;
-                    
-                    {
-                        std::unique_lock<std::mutex> lock(queue_mutex_);
-                        condition_.wait(lock, [this] { 
-                            return stop_ || !tasks_.empty(); 
-                        });
-                        
-                        if (stop_ && tasks_.empty()) {
-                            return;
-                        }
-                        
-                        task = std::move(tasks_.front());
-                        tasks_.pop();
-                    }
-                    
-                    task();
-                }
-            });
+    explicit thread_pool(
+        size_t min_threads = (std::thread::hardware_concurrency() > 0 ? std::thread::hardware_concurrency() : 2), 
+        size_t max_threads = (std::thread::hardware_concurrency() > 0 ? std::thread::hardware_concurrency() * 4 : 16),
+        size_t idle_timeout_ms = 60000) 
+        : min_threads_(min_threads), 
+          max_threads_(max_threads), 
+          idle_timeout_(idle_timeout_ms), 
+          stop_(false) {
+        
+        if (min_threads_ == 0) min_threads_ = 1;
+        if (max_threads_ < min_threads_) max_threads_ = min_threads_;
+
+        // Start core threads
+        for (size_t i = 0; i < min_threads_; ++i) {
+            spawn_thread();
         }
     }
     
@@ -61,11 +56,9 @@ public:
         
         condition_.notify_all();
         
-        for (std::thread& worker : workers_) {
-            if (worker.joinable()) {
-                worker.join();
-            }
-        }
+        // Wait for all detached threads to cleanly exit
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        shutdown_cv_.wait(lock, [this] { return active_threads_ == 0; });
     }
     
     /**
@@ -92,27 +85,111 @@ public:
             }
             
             tasks_.emplace([task]() { (*task)(); });
+            
+            // Auto-expansion logic:
+            // If there are no idle threads available to pick up this new task, 
+            // and we haven't reached the maximum allowed threads, spawn a new one.
+            if (idle_threads_ == 0 && active_threads_ < max_threads_) {
+                spawn_thread();
+            }
         }
         
         condition_.notify_one();
         return result;
     }
+
+    /**
+     * @brief Get current number of active threads (for monitoring)
+     */
+    size_t get_active_threads() const { 
+        return active_threads_.load(); 
+    }
     
 private:
-    // Worker threads
-    std::vector<std::thread> workers_;
+    void spawn_thread() {
+        active_threads_++;
+        std::thread([this]() {
+            worker_loop();
+        }).detach();
+    }
+
+    void worker_loop() {
+        bool is_shrinking = false;
+        while (true) {
+            std::function<void()> task;
+            
+            {
+                std::unique_lock<std::mutex> lock(queue_mutex_);
+                
+                idle_threads_++;
+                
+                // Wait for tasks or idle timeout
+                bool is_timeout = !condition_.wait_for(lock, idle_timeout_, [this] { 
+                    return stop_ || !tasks_.empty(); 
+                });
+                
+                idle_threads_--;
+                
+                // Exit condition 1: Destructor called and queue is empty
+                if (stop_ && tasks_.empty()) {
+                    is_shrinking = true;
+                    active_threads_--;
+                    break;
+                }
+                
+                // Exit condition 2: Thread timed out, queue is empty, and we can shrink
+                if (is_timeout && tasks_.empty() && active_threads_ > min_threads_) {
+                    is_shrinking = true;
+                    active_threads_--;
+                    break;
+                }
+
+                // Handle spurious wakeups
+                if (tasks_.empty()) {
+                    continue;
+                }
+                
+                task = std::move(tasks_.front());
+                tasks_.pop();
+            }
+            
+            // Execute the task without holding the lock
+            task();
+        }
+        
+        // Thread is terminating, update counts and notify destructor if needed
+        {
+            if (is_shrinking) {
+                std::unique_lock<std::mutex> lock(queue_mutex_);
+                if (active_threads_ == 0) {
+                    shutdown_cv_.notify_all();
+                }
+            } else {
+                std::unique_lock<std::mutex> lock(queue_mutex_);
+                active_threads_--;
+                if (active_threads_ == 0) {
+                    shutdown_cv_.notify_all();
+                }
+            }
+        }
+    }
+
+    size_t min_threads_;
+    size_t max_threads_;
+    std::chrono::milliseconds idle_timeout_;
     
-    // Task queue
+    std::atomic<size_t> active_threads_{0};
+    size_t idle_threads_{0}; // protected by queue_mutex_
+    
     std::queue<std::function<void()>> tasks_;
     
-    // Mutex and condition variable
     std::mutex queue_mutex_;
     std::condition_variable condition_;
+    std::condition_variable shutdown_cv_;
     
-    // Stop flag
-    std::atomic<bool> stop_;
+    bool stop_;
 };
 
 } // namespace mcp
 
-#endif // MCP_THREAD_POOL_H 
+#endif // MCP_THREAD_POOL_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,13 +43,14 @@ endif()
 
 # Link Google Test and MCP library
 target_link_libraries(${TEST_PROJECT_NAME} PRIVATE
-    gtest
-    gtest_main
-    gmock
-    gmock_main
+    GTest::gtest_main
     mcp
-    Threads::Threads
+    GTest::gmock
 )
+
+if (WIN32)
+    target_link_libraries(${TEST_PROJECT_NAME} PRIVATE ws2_32 wsock32 crypt32)
+endif()
 
 # If OpenSSL is found, link OpenSSL libraries
 if(OPENSSL_FOUND)


### PR DESCRIPTION
Hi there! Thank you for sharing this excellent C++ MCP framework. I've been studying the project and noticed a potential optimization opportunity in the thread pool design.

Currently, when HTTP requests arrive, they are directly placed into the thread pool's task queue and executed synchronously by a fixed number of worker threads. In MCP scenarios, tools or LLM calls can be heavily I/O-bound and time-consuming. If multiple long-running tasks occupy all core threads, new incoming lightweight requests (like `ping` or cancellation notifications) might be starved in the queue, potentially leading to timeouts.

To resolve this, I upgraded `mcp::thread_pool` to a **dynamic thread pool**:
- **Core threads**: Maintains a base number of threads (defaults to `hardware_concurrency()`).
- **Dynamic expansion**: Automatically spawns new temporary threads when all active threads are busy and new tasks arrive (up to a configurable maximum limit).
- **Idle timeout**: Automatically shrinks and cleans up idle threads after a timeout (default 60 seconds) to save system resources.

Additionally, I fixed a missing `ws2_32` link issue for the `mcp_tests` executable in `test/CMakeLists.txt` so that the unit tests can compile and run successfully natively on Windows.

All existing unit tests and the new dynamic expansion logic have been verified locally. Hope this helps improve the robustness of the framework!
