### PR TITLE
feat: add MCP Prompts primitive and server-side stdio transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,16 @@ Implements MCP server functionality.
 
 ### HTTP Server Example (`examples/server_example.cpp`)
 
-Example MCP server implementation with custom tools:
+Example MCP server implementation over HTTP/SSE with custom tools:
 - Time tool: Get the current time
 - Calculator tool: Perform mathematical operations
 - Echo tool: Echo input with optional transformations (to uppercase, reverse)
 - Greeting tool: Returns `Hello, `+ input name + `!`, defaults to `Hello, World!`
+
+### Stdio Server Example (`examples/stdio_server_example.cpp`)
+
+Example MCP server implementation over standard input/output (stdio), which is the default transport method for MCP clients like Claude Desktop, Cursor, and OpenCode.
+It implements the same core tools but uses `server.start_stdio()` to communicate via pipes instead of opening an HTTP port.
 
 ### HTTP Client Example (`examples/client_example.cpp`)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **JSON-RPC 2.0 Communication**: Request/response communication based on JSON-RPC 2.0 standard
 - **Resource Abstraction**: Standard interfaces for resources such as files, APIs, etc.
 - **Tool Registration**: Register and call tools with structured parameters
+- **Prompt Templates**: Register and expose prompt templates to clients for AI workflows
 - **Extensible Architecture**: Easy to extend with new resource types and tools
 - **Multi-Transport Support**: Supports HTTP and standard input/output (stdio) communication methods
 
@@ -85,7 +86,7 @@ Example MCP server implementation with custom tools:
 
 Example MCP client connecting to a server:
 - Get server information
-- List available tools
+- List available tools and prompts
 - Call tools with parameters
 - Access resources
 
@@ -155,6 +156,26 @@ server.register_tool(hello_tool, hello_handler);
 // Register resources
 auto file_resource = std::make_shared<mcp::file_resource>("<file_path>");
 server.register_resource("file://<file_path>", file_resource);
+
+// Register prompts
+mcp::prompt draft_prompt = mcp::prompt_builder("draft_article")
+        .with_description("Draft a new article")
+        .with_argument("topic", "The main topic to write about", true)
+        .build();
+
+server.register_prompt(draft_prompt, [](const mcp::json& args, const std::string /* session_id */) -> mcp::json {
+    std::string topic = args.value("topic", "Unknown");
+    std::string instruction = "Please write an article about " + topic;
+    
+    // Return messages array as specified in the MCP protocol
+    return mcp::json::array({{
+        {"role", "user"},
+        {"content", {
+            {"type", "text"},
+            {"text", instruction}
+        }}
+    }});
+});
 
 // Start the server
 server.start(true);  // Blocking mode

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,3 +30,8 @@ target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/include)
 if(OPENSSL_FOUND)
     target_link_libraries(${TARGET} PRIVATE ${OPENSSL_LIBRARIES})
 endif()
+
+set(TARGET stdio_server_example)
+add_executable(${TARGET} stdio_server_example.cpp)
+target_link_libraries(${TARGET} PRIVATE mcp)
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/examples/server_example.cpp
+++ b/examples/server_example.cpp
@@ -170,6 +170,29 @@ int main() {
     server.register_tool(calc_tool, calculator_handler);
     server.register_tool(hello_tool, hello_handler);
     
+    // Register prompt
+    mcp::prompt hello_prompt = mcp::prompt_builder("hello_prompt")
+        .with_description("A prompt to generate a greeting")
+        .with_argument("name", "The name to greet", true)
+        .build();
+
+    server.register_prompt(hello_prompt, [](const mcp::json& args, const std::string& session_id) -> mcp::json {
+        std::string name = "World";
+        if (args.contains("name")) {
+            name = args["name"].get<std::string>();
+        }
+
+        mcp::json message = {
+            {"role", "user"},
+            {"content", {
+                {"type", "text"},
+                {"text", "Please greet " + name + " in a friendly way."}
+            }}
+        };
+
+        return mcp::json::array({message});
+    });
+    
     // // Register resources
     // auto file_resource = std::make_shared<mcp::file_resource>("./Makefile");
     // server.register_resource("file://./Makefile", file_resource);

--- a/examples/stdio_server_example.cpp
+++ b/examples/stdio_server_example.cpp
@@ -1,9 +1,10 @@
 /**
- * @file server_example.cpp
- * @brief Server example based on MCP protocol
+ * @file stdio_server_example.cpp
+ * @brief Server example based on MCP protocol using Standard I/O transport
  * 
- * This example demonstrates how to create an MCP server, register tools and resources,
- * and handle client requests. Follows the 2024-11-05 basic protocol specification.
+ * This example demonstrates how to create an MCP server that communicates
+ * over standard input (stdin) and standard output (stdout).
+ * Follows the 2024-11-05 basic protocol specification.
  */
 #include "mcp_server.h"
 #include "mcp_tool.h"
@@ -122,20 +123,12 @@ int main() {
     
     // Create and configure server
     mcp::server::configuration srv_conf;
-    srv_conf.host = "localhost";
-    srv_conf.port = 8888;
-    // srv_conf.threadpool_size = 1;
-    // srv_conf.ssl.server_cert_path = "./server.cert.pem";
-    // srv_conf.ssl.server_private_key_path = "./server.key.pem";
-
+    // Note: host and port are ignored in stdio mode
+    
     mcp::server server(srv_conf);
-    server.set_server_info("ExampleServer", "1.0.0");
+    server.set_server_info("StdioExampleServer", "1.0.0");
     
     // Set server capabilities
-    // mcp::json capabilities = {
-    //     {"tools", {{"listChanged", true}}},
-    //     {"resources", {{"subscribe", false}, {"listChanged", true}}}
-    // };
     mcp::json capabilities = {
         {"tools", mcp::json::object()},
         {"prompts", mcp::json::object()}
@@ -199,9 +192,12 @@ int main() {
     // server.register_resource("file://./Makefile", file_resource);
     
     // Start server
-    std::cout << "Starting MCP server at " << srv_conf.host << ":" << srv_conf.port << std::endl;
-    std::cout << "Press Ctrl+C to stop the server" << std::endl;
-    server.start(true);  // Blocking mode
+    // CRITICAL: We use std::cerr here to output logs, because any output to std::cout
+    // will corrupt the JSON-RPC pipe and crash the MCP client!
+    std::cerr << "Starting MCP server in STDIO mode..." << std::endl;
+    std::cerr << "Awaiting JSON-RPC requests on stdin..." << std::endl;
+    
+    server.start_stdio();
     
     return 0;
 }

--- a/include/mcp_prompt.h
+++ b/include/mcp_prompt.h
@@ -1,0 +1,85 @@
+/**
+ * @file mcp_prompt.h
+ * @brief Prompt definitions for MCP
+ * 
+ * This file provides prompt-related functionality and abstractions for the MCP protocol.
+ */
+
+#ifndef MCP_PROMPT_H
+#define MCP_PROMPT_H
+
+#include "mcp_message.h"
+#include <string>
+#include <vector>
+#include <map>
+
+namespace mcp {
+
+// MCP Prompt Argument definition
+struct prompt_argument {
+    std::string name;
+    std::string description;
+    bool required = false;
+    
+    json to_json() const {
+        json j = {
+            {"name", name},
+            {"description", description},
+            {"required", required}
+        };
+        return j;
+    }
+};
+
+// MCP Prompt definition
+struct prompt {
+    std::string name;
+    std::string description;
+    std::vector<prompt_argument> arguments;
+
+    json to_json() const {
+        json args_json = json::array();
+        for (const auto& arg : arguments) {
+            args_json.push_back(arg.to_json());
+        }
+        
+        json j = {
+            {"name", name},
+            {"description", description}
+        };
+        
+        if (!args_json.empty()) {
+            j["arguments"] = args_json;
+        }
+        
+        return j;
+    }
+};
+
+class prompt_builder {
+public:
+    prompt_builder(const std::string& name) {
+        prompt_.name = name;
+    }
+
+    prompt_builder& with_description(const std::string& desc) {
+        prompt_.description = desc;
+        return *this;
+    }
+
+    prompt_builder& with_argument(const std::string& name, const std::string& desc, bool required = false) {
+        prompt_.arguments.push_back({name, desc, required});
+        return *this;
+    }
+
+    prompt build() const {
+        return prompt_;
+    }
+
+private:
+    prompt prompt_;
+};
+
+} // namespace mcp
+
+#endif // MCP_PROMPT_H

--- a/include/mcp_server.h
+++ b/include/mcp_server.h
@@ -12,6 +12,7 @@
 #include "mcp_message.h"
 #include "mcp_resource.h"
 #include "mcp_tool.h"
+#include "mcp_prompt.h"
 #include "mcp_thread_pool.h"
 #include "mcp_logger.h"
 
@@ -36,6 +37,7 @@ namespace mcp {
 
 using method_handler = std::function<json(const json&, const std::string&)>;
 using tool_handler = method_handler;
+using prompt_handler = method_handler;
 using notification_handler = std::function<void(const json&, const std::string&)>;
 using auth_handler = std::function<bool(const std::string&, const std::string&)>;
 using session_cleanup_handler = std::function<void(const std::string&)>;
@@ -326,6 +328,13 @@ public:
     void register_tool(const tool& tool, tool_handler handler);
 
     /**
+     * @brief Register a prompt
+     * @param prompt The prompt to register
+     * @param handler The function to call when the prompt is invoked
+     */
+    void register_prompt(const prompt& prompt, prompt_handler handler);
+
+    /**
      * @brief Register a session cleanup handler
      * @param key Tool or resource name to be cleaned up
      * @param handler The function to call when the session is closed
@@ -423,6 +432,7 @@ private:
 
     // Tools map (name -> handler)
     std::map<std::string, std::pair<tool, tool_handler>> tools_;
+    std::map<std::string, std::pair<prompt, prompt_handler>> prompts_;
     
     // Authentication handler
     auth_handler auth_handler_;

--- a/include/mcp_server.h
+++ b/include/mcp_server.h
@@ -243,11 +243,18 @@ public:
     ~server();
     
     /**
-     * @brief Start the server
-     * @param blocking If true, this call blocks until the server stops
+     * @brief Start the server (HTTP/SSE)
+     * @param blocking Whether to block the current thread
      * @return True if the server started successfully
      */
     bool start(bool blocking = true);
+    
+    /**
+     * @brief Start the server using stdio transport
+     * Reads JSON-RPC messages from stdin and writes responses to stdout.
+     * Blocks the current thread until stdin is closed.
+     */
+    void start_stdio();
     
     /**
      * @brief Stop the server

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,10 @@ target_compile_definitions(${TARGET} PUBLIC
 
 target_link_libraries(${TARGET} PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
+if(WIN32)
+    target_link_libraries(${TARGET} PUBLIC ws2_32 wsock32)
+endif()
+
 # If OpenSSL is found, link the OpenSSL libraries
 if(OPENSSL_FOUND)
     target_link_libraries(${TARGET} PUBLIC ${OPENSSL_LIBRARIES})

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -551,6 +551,54 @@ void server::register_tool(const tool& tool, tool_handler handler) {
     }
 }
 
+void server::register_prompt(const prompt& prompt, prompt_handler handler) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    prompts_[prompt.name] = std::make_pair(prompt, handler);
+    
+    // Register methods for prompt listing and calling
+    if (method_handlers_.find("prompts/list") == method_handlers_.end()) {
+        method_handlers_["prompts/list"] = [this](const json& params, const std::string& session_id) -> json {
+            json prompts_json = json::array();
+            for (const auto& [name, prompt_pair] : prompts_) {
+                prompts_json.push_back(prompt_pair.first.to_json());
+            }
+            return json{{"prompts", prompts_json}};
+        };
+    }
+    
+    if (method_handlers_.find("prompts/get") == method_handlers_.end()) {
+        method_handlers_["prompts/get"] = [this](const json& params, const std::string& session_id) -> json {
+            if (!params.contains("name")) {
+                throw mcp_exception(error_code::invalid_params, "Missing 'name' parameter");
+            }
+            
+            std::string prompt_name = params["name"];
+            auto it = prompts_.find(prompt_name);
+            if (it == prompts_.end()) {
+                throw mcp_exception(error_code::invalid_params, "Prompt not found: " + prompt_name);
+            }
+            
+            json prompt_args = params.contains("arguments") ? params["arguments"] : json::object();
+            
+            json handler_result = it->second.second(prompt_args, session_id);
+            
+            // Expected to return a GetPromptResult structure: {"description": "...", "messages": [...]}
+            // If it returns just an array, we can auto-wrap it into messages
+            if (handler_result.is_array()) {
+                json wrapped_result = {
+                    {"messages", handler_result}
+                };
+                if (!it->second.first.description.empty()) {
+                    wrapped_result["description"] = it->second.first.description;
+                }
+                return wrapped_result;
+            }
+            
+            return handler_result;
+        };
+    }
+}
+
 void server::register_session_cleanup(const std::string& key, session_cleanup_handler handler) {
     std::lock_guard<std::mutex> lock(mutex_);
     session_cleanup_handler_[key] = handler;

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -55,6 +55,67 @@ server::~server() {
     stop();
 }
 
+void server::start_stdio() {
+    running_ = true;
+    std::string line;
+    std::string session_id = "stdio_session_" + std::to_string(std::time(nullptr));
+    
+    while (std::getline(std::cin, line)) {
+        if (line.empty()) continue;
+        try {
+            json req_json = json::parse(line);
+            request req;
+            
+            if (req_json.is_object() && req_json.contains("jsonrpc") && req_json["jsonrpc"] == "2.0") {
+                req.jsonrpc = "2.0";
+                if (req_json.contains("id")) {
+                    req.id = req_json["id"];
+                } else {
+                    req.id = nullptr;
+                }
+                req.method = req_json.value("method", "");
+                if (req_json.contains("params")) {
+                    req.params = req_json["params"];
+                }
+                
+                json res = process_request(req, session_id);
+                if (!res.is_null() && !req.id.is_null()) {
+                    std::cout << res.dump() << "\n" << std::flush;
+                } else {
+                    std::cerr << "Response is null or ID is null. Method: " << req.method << std::endl;
+                    if (!res.is_null()) {
+                        std::cout << res.dump() << "\n" << std::flush;
+                    }
+                }
+            } else {
+                json err_res = {
+                    {"jsonrpc", "2.0"},
+                    {"error", {
+                        {"code", static_cast<int>(error_code::invalid_request)},
+                        {"message", "Invalid JSON-RPC format"}
+                    }}
+                };
+                if (req_json.contains("id")) {
+                    err_res["id"] = req_json["id"];
+                } else {
+                    err_res["id"] = nullptr;
+                }
+                std::cout << err_res.dump() << "\n" << std::flush;
+            }
+        } catch (const std::exception& e) {
+            json err_res = {
+                {"jsonrpc", "2.0"},
+                {"error", {
+                    {"code", static_cast<int>(error_code::parse_error)},
+                    {"message", std::string("Parse error: ") + e.what()}
+                }},
+                {"id", nullptr}
+            };
+            std::cout << err_res.dump() << "\n" << std::flush;
+        }
+    }
+    running_ = false;
+}
 
 bool server::start(bool blocking) {
     if (running_) {

--- a/test/mcp_test.cpp
+++ b/test/mcp_test.cpp
@@ -14,6 +14,9 @@
 #include "mcp_prompt.h"
 #include "mcp_sse_client.h"
 
+#include <vector>
+#include <sstream>
+
 using namespace mcp;
 using json = nlohmann::ordered_json;
 
@@ -783,3 +786,96 @@ int main(int argc, char **argv) {
     
     return RUN_ALL_TESTS();
 } 
+// Test Stdio Transport
+class StdioTransportTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Prepare original buffers
+        orig_cin = std::cin.rdbuf();
+        orig_cout = std::cout.rdbuf();
+    }
+
+    void TearDown() override {
+        // Restore buffers
+        std::cin.rdbuf(orig_cin);
+        std::cout.rdbuf(orig_cout);
+    }
+    
+    std::streambuf* orig_cin;
+    std::streambuf* orig_cout;
+};
+
+TEST_F(StdioTransportTest, StartStdioProcessing) {
+    mcp::server::configuration srv_conf;
+    mcp::server server(srv_conf);
+    
+    // Register tool
+    mcp::tool echo_tool = mcp::tool_builder("echo")
+        .with_description("Echo tool")
+        .with_string_param("text", "Text to echo", true)
+        .build();
+    
+    server.register_tool(echo_tool, [](const mcp::json& params, const std::string&) -> mcp::json {
+        return {
+            {
+                {"type", "text"},
+                {"text", params["text"]}
+            }
+        };
+    });
+
+    // Simulate input sequence
+    // 1. Initialize request
+    std::string init_req = "{\"jsonrpc\": \"2.0\", \"id\": 0, \"method\": \"initialize\", \"params\": {\"protocolVersion\": \"2025-03-26\", \"capabilities\": {}, \"clientInfo\": {\"name\": \"test_client\", \"version\": \"1.0\"}}}\n";
+    // 2. Initialized notification
+    std::string init_notif = "{\"jsonrpc\": \"2.0\", \"method\": \"notifications/initialized\"}\n";
+    // 3. Tool call request
+    std::string mock_input = "{\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"tools/call\", \"params\": {\"name\": \"echo\", \"arguments\": {\"text\": \"hello stdio test\"}}}\n";
+    
+    std::istringstream in_stream(init_req + init_notif + mock_input);
+    std::ostringstream out_stream;
+
+    std::cin.rdbuf(in_stream.rdbuf());
+    std::cout.rdbuf(out_stream.rdbuf());
+
+    // Run processing
+    // It should process the lines, then exit when EOF is reached
+    server.start_stdio();
+
+    // Verify output
+    std::string raw_output = out_stream.str();
+    ASSERT_FALSE(raw_output.empty());
+    
+    // Collect all non-empty JSON lines from stdout
+    std::istringstream output_stream(raw_output);
+    std::string line;
+    std::vector<json> responses;
+    while (std::getline(output_stream, line)) {
+        if (line.empty()) continue;
+        try {
+            responses.push_back(json::parse(line));
+        } catch (...) {
+            continue;
+        }
+    }
+    
+    // Verify we have at least the init response and tool call response
+    ASSERT_GE(responses.size(), 2);
+    
+    // Find the tool call response (id=1)
+    bool found_tool_result = false;
+    bool found_init_result = false;
+    for (const auto& resp : responses) {
+        if (resp.contains("id") && resp["id"] == 0 && resp.contains("result")) {
+            found_init_result = true;
+        }
+        if (resp.contains("id") && resp["id"] == 1 && resp.contains("result")) {
+            EXPECT_EQ(resp["jsonrpc"], "2.0");
+            EXPECT_EQ(resp["result"]["content"][0]["text"], "hello stdio test");
+            found_tool_result = true;
+        }
+    }
+    
+    EXPECT_TRUE(found_init_result) << "Missing initialize response";
+    EXPECT_TRUE(found_tool_result) << "Missing tools/call response";
+}

--- a/test/mcp_test.cpp
+++ b/test/mcp_test.cpp
@@ -11,6 +11,7 @@
 #include "mcp_client.h"
 #include "mcp_server.h"
 #include "mcp_tool.h"
+#include "mcp_prompt.h"
 #include "mcp_sse_client.h"
 
 using namespace mcp;
@@ -662,6 +663,114 @@ TEST_F(ToolsTest, CallTool) {
     EXPECT_EQ(tool_result["content"][0]["text"], "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy");
 }
 
+class PromptsEnvironment : public ::testing::Environment {
+public:
+    void SetUp() override {
+        // Set up test environment
+        server::configuration conf = {.host = "localhost", .port = 8084};
+        server_ = std::make_unique<server>(conf);
+        
+        // Create a test prompt
+        prompt test_prompt = prompt_builder("test_prompt")
+            .with_description("A test prompt")
+            .with_argument("name", "The user name", true)
+            .build();
+        
+        // Register prompt
+        server_->register_prompt(test_prompt, [](const json& params, const std::string& /* session_id */) -> json {
+            std::string name = "World";
+            if (params.contains("name")) {
+                name = params["name"].get<std::string>();
+            }
+            
+            return json::array({
+                {
+                    {"role", "user"},
+                    {"content", {
+                        {"type", "text"},
+                        {"text", "Hello, " + name + "!"}
+                    }}
+                }
+            });
+        });
+        
+        // Start server in background thread
+        server_thread_ = std::thread([this]() {
+            server_->start();
+        });
+        
+        // Wait for server to start
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        
+        // Connect client
+        client_ = std::make_unique<sse_client>("http://localhost:8084");
+        bool initialized = client_->initialize("TestClient", "1.0");
+        EXPECT_TRUE(initialized);
+    }
+
+    void TearDown() override {
+        if (client_) {
+            client_.reset();
+        }
+        if (server_) {
+            server_->stop();
+        }
+        if (server_thread_.joinable()) {
+            server_thread_.join();
+        }
+    }
+
+    static std::shared_ptr<sse_client>& GetClient() {
+        return client_;
+    }
+
+private:
+    std::unique_ptr<server> server_;
+    std::thread server_thread_;
+    static std::shared_ptr<sse_client> client_;
+};
+
+std::shared_ptr<sse_client> PromptsEnvironment::client_ = nullptr;
+
+class PromptsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        client_ = PromptsEnvironment::GetClient().get();
+    }
+
+    sse_client* client_;
+};
+
+// Test listing prompts
+TEST_F(PromptsTest, ListPrompts) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    
+    // Call list prompts method directly
+    json prompts_list = client_->send_request("prompts/list").result;
+    
+    // Verify prompts list
+    EXPECT_TRUE(prompts_list.contains("prompts"));
+    EXPECT_EQ(prompts_list["prompts"].size(), 1);
+    EXPECT_EQ(prompts_list["prompts"][0]["name"], "test_prompt");
+    EXPECT_EQ(prompts_list["prompts"][0]["description"], "A test prompt");
+    EXPECT_TRUE(prompts_list["prompts"][0].contains("arguments"));
+    EXPECT_EQ(prompts_list["prompts"][0]["arguments"][0]["name"], "name");
+}
+
+// Test getting prompt
+TEST_F(PromptsTest, GetPrompt) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    
+    // Get prompt
+    json prompt_result = client_->send_request("prompts/get", {{"name", "test_prompt"}, {"arguments", {{"name", "Alice"}}}}).result;
+    
+    // Verify prompt result
+    EXPECT_TRUE(prompt_result.contains("messages"));
+    EXPECT_EQ(prompt_result["messages"].size(), 1);
+    EXPECT_EQ(prompt_result["messages"][0]["role"], "user");
+    EXPECT_EQ(prompt_result["messages"][0]["content"]["text"], "Hello, Alice!");
+}
+
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     
@@ -670,6 +779,7 @@ int main(int argc, char **argv) {
     ::testing::AddGlobalTestEnvironment(new VersioningEnvironment());
     ::testing::AddGlobalTestEnvironment(new PingEnvironment());
     ::testing::AddGlobalTestEnvironment(new ToolsEnvironment());
+    ::testing::AddGlobalTestEnvironment(new PromptsEnvironment());
     
     return RUN_ALL_TESTS();
 } 


### PR DESCRIPTION
## Summary

This PR adds two major enhancements to the `cpp-mcp` SDK:

1. **Prompts primitive** — the third core pillar of the MCP protocol (alongside Tools and Resources)
2. **Server-side stdio transport** — enabling pipeline-based communication for local MCP clients

---

## 1. Prompts Primitive

### What
Prompts allow servers to expose prompt templates (with structured arguments) to human-in-the-loop clients or AI agents, enabling complex, standardized workflows through the MCP standard.

### Changes
- **`mcp_prompt.h`** — Abstraction definitions for `prompt` and `prompt_argument`, including a fluent `prompt_builder` for ergonomic prompt creation.
- **`mcp_server.h/cpp`** — Added `prompts_` registry, `register_prompt` method, `prompts/list` handler (to expose available templates), and `prompts/get` handler (to execute prompts with argument parsing).
- **`README.md`** — Documented prompt registration and usage, matching the existing documentation style for Tools and Resources.
- **Tests** — Unit tests for prompt registration, list, and get are included in the test suite.

### Why
Prior to this change, `cpp-mcp` supported Tools and Resources natively but was missing the third core pillar of MCP: Prompts. This addition allows `cpp-mcp` servers to seamlessly integrate with MCP clients (Claude Desktop, Cursor, OpenCode) that utilize prompt templates.

---

## 2. Server-side Stdio Transport

### What
A `server::start_stdio()` method that reads JSON-RPC messages from `std::cin` and writes responses to `std::cout`, enabling stdio-based communication with MCP clients.

### Changes
- **`include/mcp_server.h`, `src/mcp_server.cpp`** — New `start_stdio()` method implementing a blocking read loop that processes JSON-RPC requests via the existing internal `process_request()` pipeline. Includes error handling for invalid JSON.
- **`examples/stdio_server_example.cpp`** — A complete server example over stdio transport, fully mirroring the existing `server_example.cpp` (same tools and prompts, different transport).
- **`examples/CMakeLists.txt`** — Added build target for the new example.
- **`examples/server_example.cpp`** — Fix: explicitly declare `"prompts"` capability (was missing despite registering prompts).
- **`README.md`** — Documented the new example alongside the existing HTTP server example.
- **Tests** — `StdioTransportTest.StartStdioProcessing` verifies correct handling of `initialize`, `notifications/initialized`, and `tools/call` requests through simulated stdin/stdout.

### Why
The README already claimed "Multi-Transport Support: Supports HTTP and stdio", but the server code only implemented HTTP (the `server::start()` method was hardcoded to HTTP/SSE). Clients like Claude Desktop, Cursor, and OpenCode that spawn MCP servers as subprocesses over stdio pipes were unable to establish a connection. This mirrors the pattern used in the official [Python MCP SDK's `stdio_server()`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/stdio.py).

---

## Testing

```bash
cmake --build build
build/test/mcp_tests.exe --gtest_filter="*-VersioningTest.UnsupportedVersion"
# [  PASSED  ] 13 tests. (14 total; 1 pre-existing crash in VersioningTest.UnsupportedVersion is unrelated)
```

- ✅ Prompts: `PromptsTest.ListPrompts`, `PromptsTest.GetPrompt`
- ✅ Stdio: `StdioTransportTest.StartStdioProcessing`
- ✅ All existing tests continue to pass