### PR TITLE
Fix SSE pending request id key consistency

### DIFF
--- a/include/mcp_message.h
+++ b/include/mcp_message.h
@@ -123,7 +123,7 @@ private:
     // Generate a unique ID
     static json generate_id() {
         static int next_id = 1;
-        return next_id++;
+        return json(next_id++);  // Explicitly create json to ensure type consistency
     }
 };
 

--- a/include/mcp_sse_client.h
+++ b/include/mcp_sse_client.h
@@ -234,8 +234,8 @@ private:
     // Condition variable, used to wait for message endpoint setting
     std::condition_variable endpoint_cv_;
     
-    // Request ID to Promise mapping, used for asynchronous waiting for responses
-    std::map<json, std::promise<json>> pending_requests_;
+    // Request ID to Promise mapping (using string key for type consistency)
+    std::map<std::string, std::promise<json>> pending_requests_;
     
     // Response processing mutex
     std::mutex response_mutex_;

--- a/src/mcp_sse_client.cpp
+++ b/src/mcp_sse_client.cpp
@@ -45,7 +45,7 @@ void sse_client::init_client(const std::string& scheme_host_port, bool validate_
 
 bool sse_client::initialize(const std::string& client_name, const std::string& client_version) {
     LOG_INFO("Initializing MCP client...");
-    
+
     request req = request::create("initialize", {
         {"protocolVersion", MCP_VERSION},
         {"capabilities", capabilities_},
@@ -263,17 +263,17 @@ void sse_client::open_sse_connection() {
                 LOG_INFO("SSE thread: Attempting to connect to ", sse_endpoint_);
                 
                 std::string buffer;
-                auto res = sse_client_->Get(sse_endpoint_, 
+                auto res = sse_client_->Get(sse_endpoint_,
                     [&,this](const char *data, size_t data_length) {
                         buffer.append(data, data_length);
-                        
+
                         // Normalize CRLF to LF
                         size_t crlf_pos = buffer.find("\r\n");
                         while (crlf_pos != std::string::npos) {
                             buffer.replace(crlf_pos, 2, "\n");
                             crlf_pos = buffer.find("\r\n", crlf_pos + 1);
                         }
-                        
+
                         // Process complete events in buffer
                         size_t start_pos = 0;
                         while ((start_pos = buffer.find("\n\n", start_pos)) != std::string::npos) {
@@ -281,12 +281,12 @@ void sse_client::open_sse_connection() {
                             std::string event = buffer.substr(0, start_pos);
                             buffer.erase(0, end_pos);
                             start_pos = 0;
-                            
+
                             if (!parse_sse_data(event.data(), event.size())) {
                                 LOG_ERROR("SSE thread: Failed to parse event");
                             }
                         }
-                        
+
                         return sse_running_.load();
                     });
                 
@@ -374,12 +374,13 @@ bool sse_client::parse_sse_data(const char* data, size_t length) {
         } else if (event_type == "message") {
             try {
                 json response = json::parse(data_content);
-                
+
                 if (response.contains("jsonrpc") && response.contains("id") && !response["id"].is_null()) {
-                    json id = response["id"];
-                    
+                    // Use the same serialization method as when storing the request ID
+                    std::string id_key = response["id"].dump();
+
                     std::lock_guard<std::mutex> lock(response_mutex_);
-                    auto it = pending_requests_.find(id);
+                    auto it = pending_requests_.find(id_key);
                     if (it != pending_requests_.end()) {
                         if (response.contains("result")) {
                             it->second.set_value(response["result"]);
@@ -392,10 +393,10 @@ bool sse_client::parse_sse_data(const char* data, size_t length) {
                         } else {
                             it->second.set_value(json::object());
                         }
-                        
+
                         pending_requests_.erase(it);
                     } else {
-                        LOG_WARNING("Received response for unknown request ID: ", id);
+                        LOG_WARNING("Received response for unknown request ID: ", id_key);
                     }
                 } else {
                     LOG_WARNING("Received invalid JSON-RPC response: ", response.dump());
@@ -492,10 +493,14 @@ json sse_client::send_jsonrpc(const request& req) {
     
     std::promise<json> response_promise;
     std::future<json> response_future = response_promise.get_future();
-    
+
+    // Use the JSON-serialized id as key to ensure type consistency
+    json req_id_json = req.to_json()["id"];
+    std::string req_id_key = req_id_json.dump();
+
     {
         std::lock_guard<std::mutex> response_lock(response_mutex_);
-        pending_requests_[req.id] = std::move(response_promise);
+        pending_requests_[req_id_key] = std::move(response_promise);
     }
     
     auto result = http_client_->Post(msg_endpoint_, headers, req_body, "application/json");
@@ -506,7 +511,7 @@ json sse_client::send_jsonrpc(const request& req) {
         
         {
             std::lock_guard<std::mutex> response_lock(response_mutex_);
-            pending_requests_.erase(req.id);
+            pending_requests_.erase(req_id_key);
         }
         
         LOG_ERROR("JSON-RPC request failed: ", error_msg);
@@ -519,7 +524,7 @@ json sse_client::send_jsonrpc(const request& req) {
             
             {
                 std::lock_guard<std::mutex> response_lock(response_mutex_);
-                pending_requests_.erase(req.id);
+                pending_requests_.erase(req_id_key);
             }
             
             if (res_json.contains("error")) {
@@ -537,7 +542,7 @@ json sse_client::send_jsonrpc(const request& req) {
         } catch (const json::exception& e) {
             {
                 std::lock_guard<std::mutex> response_lock(response_mutex_);
-                pending_requests_.erase(req.id);
+                pending_requests_.erase(req_id_key);
             }
             
             throw mcp_exception(error_code::parse_error, 
@@ -565,7 +570,7 @@ json sse_client::send_jsonrpc(const request& req) {
         } else {
             {
                 std::lock_guard<std::mutex> response_lock(response_mutex_);
-                pending_requests_.erase(req.id);
+                pending_requests_.erase(req_id_key);
             }
             
             throw mcp_exception(error_code::internal_error, "Timeout waiting for SSE response");


### PR DESCRIPTION
- Use JSON-serialized request id as the pending_requests_ map key to avoid numeric type mismatches between request and response ids.
- Make request::generate_id() explicitly return a JSON value for type clarity.
- This stabilizes response matching in the SSE client when id types differ (e.g., signed vs unsigned).