### PR TITLE
feat: pass session_id to session_cleanup_handler

### DIFF
--- a/include/mcp_server.h
+++ b/include/mcp_server.h
@@ -38,7 +38,7 @@ using method_handler = std::function<json(const json&, const std::string&)>;
 using tool_handler = method_handler;
 using notification_handler = std::function<void(const json&, const std::string&)>;
 using auth_handler = std::function<bool(const std::string&, const std::string&)>;
-using session_cleanup_handler = std::function<void(const std::string&)>;
+using session_cleanup_handler = std::function<void(const std::string& key, const std::string& session_id)>;
 
 class event_dispatcher {
 public:

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -1399,7 +1399,7 @@ void server::close_session(const std::string& session_id) {
      // Clean up resources safely
     try {
         for (const auto& [key, handler] : session_cleanup_handler_) {
-            handler(key);
+            handler(key, session_id);
         }
 
         // Copy resources to be processed


### PR DESCRIPTION
This pull request updates how session cleanup handlers are defined and invoked in the codebase. The main change is that session cleanup handlers now receive both the resource key and the session ID, allowing for more context-aware cleanup logic.

**Session cleanup handler improvements:**

* Updated the type definition of `session_cleanup_handler` in `mcp_server.h` so that handlers now take both a `key` and a `session_id` as arguments, instead of just the `key`.
* Modified the invocation of session cleanup handlers in `server::close_session` in `mcp_server.cpp` to pass both the `key` and `session_id` to each handler.